### PR TITLE
Update implementation + schema for evaluated->hiccup

### DIFF
--- a/src/site/fabricate/prototype/write.clj
+++ b/src/site/fabricate/prototype/write.clj
@@ -214,7 +214,8 @@
 (defn evaluated->hiccup
   "Takes the evaluated contents and turns them into a well-formed
    hiccup data structure."
-  {:malli/schema [:=> [:cat evaluated-state state-schema] :map]}
+  {:malli/schema [:=> [:cat evaluated-state state-schema]
+                  html/html]}
   [{:keys [site.fabricate.page/namespace
            site.fabricate.page/metadata
            site.fabricate.page/evaluated-content]
@@ -225,11 +226,11 @@
         body-content (into [:article {:lang "en"}]
                            (page/parse-paragraphs
                             evaluated-content))]
-    (list
+    [:html
      (doc-header metadata)
-     [:article body-content]
-     [:footer
-      [:div [:a {:href "/"} "Home"]]])))
+     [:body [:article body-content]
+      [:footer
+       [:div [:a {:href "/"} "Home"]]]]]))
 
 (def rendered-state
   (mu/merge
@@ -286,7 +287,9 @@
                   (assoc page-data
                          :site.fabricate.page/evaluated-content final-hiccup
                          :site.fabricate.page/rendered-content
-                         (hp/html5 {:lang :en-us} final-hiccup))))
+                         (str (hiccup/html
+                               {:escape-strings? false}
+                               final-hiccup)))))
    rendered-state
    (fn [{:keys [site.fabricate.page/rendered-content
                 site.fabricate.file/output-file] :as page-data}

--- a/test/site/fabricate/prototype/test_utils.clj
+++ b/test/site/fabricate/prototype/test_utils.clj
@@ -6,6 +6,6 @@
 
 (defn with-instrumentation [f]
   (mi/collect!)
-  #_(mi/instrument!)
+  (mi/instrument!)
   (f)
-  #_(mi/unstrument!))
+  (mi/unstrument!))


### PR DESCRIPTION
This provides a consistent HTML output for the final function prior to
being turned into an HTML string for output. Addresses #34.