### PR TITLE
Fix agent error caused by nil application state

### DIFF
--- a/pages/design/queue.html.fab
+++ b/pages/design/queue.html.fab
@@ -1,0 +1,32 @@
+✳ (ns site.fabricate.docs.design.queue
+  (:require
+   [clojure.string :as str]
+   [site.fabricate.prototype.write :as write]  
+   [garden.core  :as garden]
+   [garden.stylesheet :as stylesheet]
+   [site.fabricate.styles :as styles]
+   [site.fabricate.prototype.page :as page])) 🔚
+   
+✳(def metadata {:title "Design Doc for Work Queue"
+               :written  "2022-10-10"
+               :page-style (garden/css styles/docs)})🔚
+               
+✳=[:h1 {:class "xl-text"} (:title metadata)]🔚
+✳=[:h4 (str (:written metadata))]🔚
+
+The approach of "put everything in the same agent" is starting to show its  ✳=[:a {:href "https://github.com/fabricate-site/fabricate/commit/e6a972dbdeb4e93bab582d064a029844f4394cc1"} "limitations"]🔚. It would be better to use a work queue to manage the state of pages that need to be re-rendered. 
+✳=[:h2 "Preliminaries"]🔚
+ 
+Pages are (usually) independent of one another. This means they can be processed concurrently. 
+
+Clojure's PersistentQueues (by themselves) may not be the right choice, according to The Joy of Clojure:
+
+✳=[:blockquote "...it's important to point out that Clojure's PersistentQueue is a collection, not a workflow mechanism. Java has classes deriving from the java.util.concurrent.BlockingQueue interface for workflow, which often are useful in Clojure programs, and those aren't these. If you find yourself wanting to repeatedly check a work queue to see if there's an item of work to be popped off, or if you want to use a queue to send a task to another thread, you do not want the PersistentQueue, because it's an immutable structure; thus there's no way to inherently communicate changes from one worker to another."] 🔚
+
+Wrapping a PersistentQueue in a atom may be the way to obtain a synchronization point across threads. However, that type of explicit scheduling may not be necessary.
+
+✳=[:h2 "Futures"]🔚
+
+The page-rerendering loop could be implemented via ✳=[:code "future"]🔚. Since the contents of the page aren't actually needed by the main loop of Fabricate until they are to be written to output HTML, there could simply be a queue of Futures, executed in the background, then dereferenced sequentially when the program needs to write. This atomic operation could also ✳=[:code "swap!"]🔚 the finished page into an atom containing all the "current" pages.
+
+It isn't at all clear to me that it needs to be more complicated than this. ✳=[:code "core.async"]🔚 is probably overkill at this point.

--- a/src/site/fabricate/prototype/read.clj
+++ b/src/site/fabricate/prototype/read.clj
@@ -34,6 +34,10 @@
     [:file {:optional true :doc "The source file of the expression"}
      :string]]))
 
+(def ^{:malli/schema
+       [:=> [:cat :any] :boolean]}
+  fabricate-expr? (m/validator parsed-expr-schema))
+
 (def evaluated-expr-schema
   "Schema describing a map containing the results of an evaluated Fabricate expression."
   (-> parsed-expr-schema
@@ -310,7 +314,7 @@
      (binding [*ns* nmspc]
        (refer-clojure)
        (clojure.walk/postwalk
-        (fn [i] (if (m/validate parsed-expr-schema i)
+        (fn [i] (if (fabricate-expr? i)
                   (eval-parsed-expr i simplify?)
                   i))
         parsed-form))))

--- a/src/site/fabricate/prototype/write.clj
+++ b/src/site/fabricate/prototype/write.clj
@@ -363,12 +363,22 @@
                      v?))
          #_ #_:error-mode :continue))
 
+(comment
+  (add-watch state
+             :monitor-state
+             (fn [k reff old-state new-state]
+               (println "Previous state valid?" (valid-state? old-state))
+               (println "Current state valid?" (valid-state? new-state))))
+                                        ; doesn't seem to work.
+  (remove-watch state :monitor-state)
+
+  )
 
 (defn rerender
   "Render the given page on file change."
   {:malli/schema
-   [:=> [:cat [:map [:file :any] [:count :int] [:action :keyword]]
-         state-schema]
+   [:=> [:cat state-schema
+         [:map [:file :any] [:count :int] [:action :keyword]]]
     state-schema]}
   [{:keys [site.fabricate/settings site.fabricate/pages]
     :as application-state-map}
@@ -432,7 +442,7 @@
             (let [state-agent *agent*
                   fw (watch-dir
                       (fn [f]
-                        (do (send-off state-agent rerender f)))
+                        (do (send-off state-agent rerender f) nil))
                       (io/file input-dir))]
               (alter-meta! fw assoc :context :site.fabricate.app/watcher)
               (set-error-mode! fw :continue)

--- a/src/site/fabricate/prototype/write.clj
+++ b/src/site/fabricate/prototype/write.clj
@@ -419,7 +419,9 @@
           (println "rendered")
           (assoc-in application-state-map
                     [:site.fabricate/pages local-file]
-                    updated-page))))))
+                    updated-page)))
+      application-state-map)))
+
 
 (comment
   (fsm/complete
@@ -528,7 +530,8 @@
 
   (-> state
       (send (constantly initial-state))
-      (send-off draft!))
+      (send-off draft!)
+      )
 
   (do
     (send-off state stop!)

--- a/src/site/fabricate/prototype/write.clj
+++ b/src/site/fabricate/prototype/write.clj
@@ -344,7 +344,7 @@
   {:site.fabricate/settings default-site-settings
    :site.fabricate/pages {}})
 
-(defn report-error [a err]
+(defn- report-error [a err]
   (println "Agent context:" (:context (meta a)))
   (let [err-map (Throwable->map err)
         agent-schema (:malli/schema (meta a))]
@@ -356,8 +356,10 @@
           (println "Valid?" (m/validate agent-schema @a))
           (println (m/explain agent-schema @a))))))
 
-(def valid-state? (m/validator state-schema))
-(def explain-state (m/explainer state-schema))
+(def ^{:malli/schema [:=> [:cat :any] :boolean]}
+  valid-state? (m/validator state-schema))
+(def ^{:malli/schema [:=> [:cat :any] :map]}
+  explain-state (m/explainer state-schema))
 
 (def state
   "This agent holds the current state of all the pages created by Fabricate, the application settings, and the state of the application itself"

--- a/src/site/fabricate/prototype/write.clj
+++ b/src/site/fabricate/prototype/write.clj
@@ -510,12 +510,16 @@
                             (close-watcher %)) :stopped)
                       (catch Exception e :error/shutdown))))
       (update :site.fabricate.app/server
-              #(do
-                 (println "stopping file server")
-                 (when (and % (not (#{:stopped :error/shutdown})))
-                   (do (server/stop %) :stopped))
-                 #_(try (do (server/stop %) nil)
-                        (catch Exception e nil))))))
+              (fn [s]
+                (if (and s (not (#{:stopped :error/shutdown} s)))
+                  (do
+                    (println "stopping file server")
+                    (server/stop s) :stopped)
+                  (do (println "server not found")
+                      (println "server:" s)
+                      s)))
+              #_(try (do (server/stop %) nil)
+                     (catch Exception e nil)))))
 
 (.addShutdownHook (java.lang.Runtime/getRuntime)
                   (Thread. (fn []

--- a/test/site/fabricate/prototype/test_utils.clj
+++ b/test/site/fabricate/prototype/test_utils.clj
@@ -1,11 +1,30 @@
 (ns site.fabricate.prototype.test-utils
   (:require
    [malli.core :as m]
+   [malli.error :as me]
    [malli.instrument :as mi]
-   [clojure.test :as t]))
+   [clojure.test :as t]
+   [clojure.pprint :as pprint]))
 
 (defn with-instrumentation [f]
   (mi/collect!)
   (mi/instrument!)
   (f)
   (mi/unstrument!))
+
+(defmethod t/assert-expr 'valid-schema? [msg form]
+  `(let [schema# ~(nth form 1)
+         form# (m/form schema#)
+         data# ~(nth form 2)
+         result# (m/validate schema# data#)
+         schema-name# (last form#)]
+     (t/do-report
+      {:type (if result# :pass :fail)
+       :message ~msg
+       :expected (str (with-out-str (pprint/pprint data#))
+                      " conforms to schema for "
+                      schema-name#)
+       :actual  (if (not result#)
+                  (me/humanize (m/explain schema# data#))
+                  result#)})
+     result#))

--- a/test/site/fabricate/prototype/write_test.clj
+++ b/test/site/fabricate/prototype/write_test.clj
@@ -358,7 +358,7 @@ Some more text")
             extra-content-str
             :append true)
       (await test-state)
-      (Thread/sleep 250)
+      (Thread/sleep 500)
       (t/is (re-find #"four" (:body (curl/get (str url "/test-file.html") {:throw false})))
             "File should have contents updated by filewatcher")
 

--- a/test/site/fabricate/prototype/write_test.clj
+++ b/test/site/fabricate/prototype/write_test.clj
@@ -289,10 +289,9 @@ Some more text")
                 "./test-resources/fab/inputs/test-file.html.fab")
           res (rerender test-config
                         {:file (io/file f) :count 1 :action :create})
-          rendered-str (get-in res [:site.fabricate/pages
-                                    "test-resources/fab/inputs/test-file.html.fab"
-                                    :site.fabricate.page/rendered-content])]
-      (t/is (valid-state? res) "Rerender fn should return valid state maps")
+          rendered-str (get res :site.fabricate.page/rendered-content)]
+      (t/is (valid-schema? page-metadata-schema res)
+            "Rerender fn should return valid page maps")
       (t/is
        (re-find #"example" rendered-str))
 

--- a/test/site/fabricate/prototype/write_test.clj
+++ b/test/site/fabricate/prototype/write_test.clj
@@ -291,6 +291,11 @@ Some more text")
   (t/testing "ability to manage server state using send and draft!"
     (let [url "http://localhost:9223"]
 
+      (add-watch test-state
+                 :test-validity
+                 (fn [k reff old-state new-state]
+                   (t/is (valid-state? old-state) "Old state should be valid")
+                   (t/is (valid-state? new-state) "New state should be valid")))
       (println "0. overriding default state")
       (send test-state (constantly test-config))
       (await test-state)

--- a/test/site/fabricate/prototype/write_test.clj
+++ b/test/site/fabricate/prototype/write_test.clj
@@ -335,6 +335,11 @@ Some more text")
       (await test-state)
       (t/is (#{200 304} (:status (curl/get url {:throw false})))
             "Server should start via agent")
+      (t/is (some? (type (get @test-state :site.fabricate.app/server)))
+            "Server should be found in state agent")
+
+      (t/is (some? (type (get @test-state :site.fabricate.app/watcher)))
+            "File watcher should be found in state agent")
 
       (println "2. initial write")
       (spit "./test-resources/fab/inputs/test-file.html.fab"
@@ -369,7 +374,11 @@ Some more text")
       (await test-state)
 
       (t/is (nil? (:status (curl/get url {:throw false})))
-            "Server should shutdown via agent")))
+            "Server should shutdown via agent")
+      (t/is (= :stopped (:site.fabricate.app/server @test-state))
+            "Server shutdown should be indicated in state map")
+      (t/is (= :stopped (:site.fabricate.app/watcher @test-state))
+            "Watcher shutdown should be indicated in state map")))
 
   (println "deleting test dir")
   (delete-directory-recursive (io/file "test-resources/fab")))

--- a/test/site/fabricate/prototype/write_test.clj
+++ b/test/site/fabricate/prototype/write_test.clj
@@ -276,6 +276,7 @@ Some more text")
           rendered-str (get-in res [:site.fabricate/pages
                                     "test-resources/fab/inputs/test-file.html.fab"
                                     :site.fabricate.page/rendered-content])]
+      (t/is (valid-state? res) "Rerender fn should return valid state maps")
       (t/is
        (re-find #"example" rendered-str))
 


### PR DESCRIPTION
Addresses #40. Working through this bug led me to discover that the file-watcher wasn't playing nicely with auto-saved filenames, causing the rerender loop to run on created and deleted placeholder files, sometimes yielding `nil` for the entire application state. 

It might be useful to rework the rerender fn so it updates the application state agent in a more targeted way before merging this PR.