### PR TITLE
Add default collect multimethods for source files.

### DIFF
--- a/src/site/fabricate/api.clj
+++ b/src/site/fabricate/api.clj
@@ -180,10 +180,13 @@ A site is the primary map passed between the 3 core API functions: plan!, assemb
                                      ;; this is superfluous and can be
                                      ;; eliminated now
                                      output     (:site.fabricate.page/outputs
-                                                 entry-data)]
-                                 (-> entry-data
-                                     (dissoc :site.fabricate.page/outputs)
-                                     (merge output))))]
+                                                 entry-data
+                                                 [:default])]
+                                 (if (= output :default)
+                                   entry-data
+                                   (-> entry-data
+                                       (dissoc :site.fabricate.page/outputs)
+                                       (merge output)))))]
     (update post-setup-site
             :site.fabricate.api/entries
             (fn [es] (reduce conj es collected-entries)))))
@@ -258,3 +261,6 @@ A site is the primary map passed between the 3 core API functions: plan!, assemb
         sorted-entries entries]
     (doseq [e entries] (produce! e options))
     (reduce (fn [site task] (task site)) init-site sorted-tasks)))
+
+
+(comment)

--- a/src/site/fabricate/api.clj
+++ b/src/site/fabricate/api.clj
@@ -177,8 +177,9 @@ A site is the primary map passed between the 3 core API functions: plan!, assemb
   (let [post-setup-site   (reduce (fn [site task] (task site)) site setup-tasks)
         collected-entries (vec (for [[source _] (.getMethodTable collect)
                                      entry-data (collect source options)
-                                     ;; this is superfluous and can be
-                                     ;; eliminated now
+                                     ;; this is superfluous, but is
+                                     ;; retained for backwards
+                                     ;; compatibility
                                      output     (:site.fabricate.page/outputs
                                                  entry-data
                                                  [:default])]

--- a/src/site/fabricate/source.clj
+++ b/src/site/fabricate/source.clj
@@ -1,0 +1,53 @@
+(ns site.fabricate.source
+  "Default sources for Fabricate"
+  (:require [site.fabricate.api :as api]
+            [site.fabricate.prototype.source.clojure :as clj]
+            [site.fabricate.prototype.source.fabricate :as fabricate]
+            [babashka.fs :as fs])
+  (:import [java.time ZonedDateTime ZoneId]))
+
+(def defaults
+  "Default options for sources."
+  {::location (fs/file (System/getProperty "user.dir") "docs")})
+
+(defn- filetime->zdt
+  [ft]
+  (ZonedDateTime/ofInstant (fs/file-time->instant ft) (ZoneId/systemDefault)))
+
+(defn file-times
+  "Return a map with two ZonedDateTimes representing when the file was created and modified."
+  [f]
+  {::created  (filetime->zdt (fs/creation-time f))
+   ::modified (filetime->zdt (fs/last-modified-time f))})
+
+(defmethod api/collect "**/*.clj"
+  [src
+   {source-location ::location
+    :or {source-location (::location defaults)}
+    :as opts}]
+  (let [clj-files (fs/glob source-location src)]
+    (mapv (fn clj-path->entry [p]
+            (merge (file-times p)
+                   {::format     ::clj/v0
+                    ::location   source-location
+                    ::api/source src
+                    :site.fabricate.document/format :hiccup
+                    :site.fabricate.page/format :html
+                    ::file       (fs/file p)}))
+          clj-files)))
+
+(defmethod api/collect "**/*.fab"
+  [src
+   {source-location ::location
+    :or {source-location (::location defaults)}
+    :as opts}]
+  (let [fabricate-templates (fs/glob source-location src)]
+    (mapv (fn template->entry [p]
+            (merge (file-times p)
+                   {::format     ::fabricate/v0
+                    ::file       (fs/file p)
+                    ::api/source src
+                    ::location   source-location
+                    :site.fabricate.document/format :hiccup
+                    :site.fabricate.page/format :html}))
+          fabricate-templates)))

--- a/test/site/fabricate/api_test.clj
+++ b/test/site/fabricate/api_test.clj
@@ -1,8 +1,6 @@
 (ns site.fabricate.api-test
   (:require [clojure.test :as t]
             [site.fabricate.api :as api]
-            ;; register default collect methods
-            [site.fabricate.source :as source]
             ;; refer the dev ns to ensure multimethods have impls
             [site.fabricate.dev.build]
             [site.fabricate.prototype.test-utils :refer [with-instrumentation]]
@@ -46,19 +44,6 @@
 
 (def valid-entry? (m/validator api/entry-schema))
 (def explain-entry (m/explainer api/entry-schema))
-
-(t/deftest default-multimethods
-  (t/testing "clojure"
-    (let [entries (api/collect "**/*.clj"
-                               {:site.fabricate.source/location "."})]
-      (doseq [e entries]
-        (t/testing (:site.fabricate.source/location e)
-          (let [built-entry (api/build e {})]
-            (when-not (valid-entry? built-entry)
-              (println (me/humanize (explain-entry built-entry))))
-            (t/is (valid-entry? built-entry)
-                  "Arbitrary clojure sources should build without errors")))))))
-
 
 
 (t/deftest operations

--- a/test/site/fabricate/source_test.clj
+++ b/test/site/fabricate/source_test.clj
@@ -1,0 +1,19 @@
+(ns site.fabricate.source-test
+  (:require [clojure.test :as t]
+            [site.fabricate.api :as api]
+            [site.fabricate.source :as source]
+            [malli.core :as m]
+            [malli.util :as mu]
+            [malli.error :as me]))
+
+(t/deftest default-multimethods
+  (t/testing "clojure"
+    (let [entries (api/collect "**/*.clj"
+                               {:site.fabricate.source/location "."})]
+      (doseq [e entries]
+        (t/testing (:site.fabricate.source/location e)
+          (let [built-entry (api/build e {})]
+            (when-not (m/validate api/entry-schema built-entry)
+              (println (me/humanize (m/explain api/entry-schema built-entry))))
+            (t/is (m/validate api/entry-schema built-entry)
+                  "Arbitrary clojure sources should build without errors")))))))


### PR DESCRIPTION
This PR provides default multimethods for `site.fabricate.api/collect` for Clojure source code and Fabricate templates.

It also fixes issue #61 in a backwards-compatible way by adding a fallback to `site.fabricate.api/plan!`.