### PR TITLE
Add general-purpose build test namespace

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,15 +6,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
-      - uses: actions/cache@v4.2.2
+        uses: actions/checkout@v6.0.2
+      - uses: actions/cache@v5.0.5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Install clojure tools-deps
-        uses: DeLaGuardo/setup-clojure@13.2
+        uses: DeLaGuardo/setup-clojure@13.6.0
         with:
           cli: 1.12.0.1530
       - name: Run Tests

--- a/deps.edn
+++ b/deps.edn
@@ -12,7 +12,7 @@
                       {babashka/babashka.curl {:mvn/version "0.1.2"}
                        com.brunobonacci/mulog {:mvn/version "0.9.0"}
                        com.gfredericks/test.chuck {:mvn/version "0.2.14"}
-                       nu.validator/validator {:mvn/version "20.7.2"}
+                       nu.validator/validator {:mvn/version "26.2.19"}
                        nubank/matcher-combinators {:mvn/version "3.10.0"}
                        org.clojure/test.check {:mvn/version "1.1.1"}
                        org.scicloj/kindly {:mvn/version "4-beta18"}

--- a/deps.edn
+++ b/deps.edn
@@ -12,7 +12,7 @@
                        com.brunobonacci/mulog {:mvn/version "0.9.0"}
                        com.gfredericks/test.chuck {:mvn/version "0.2.14"}
                        nu.validator/validator {:mvn/version "20.7.2"}
-                       nubank/matcher-combinators {:mvn/version "3.9.1"}
+                       nubank/matcher-combinators {:mvn/version "3.10.0"}
                        org.clojure/test.check {:mvn/version "1.1.1"}
                        org.scicloj/kindly {:mvn/version "4-beta18"}
                        org.scicloj/kindly-render {:mvn/version "0.1.5-alpha"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,39 +1,40 @@
-{:aliases {:runner   {:exec-args {:excludes [:performance]
-                                  :patterns ["^(?!.*performance).*$"]}
-                      :exec-fn cognitect.test-runner.api/test
-                      :extra-deps
-                      {io.github.cognitect-labs/test-runner
-                       {:git/url "https://github.com/cognitect-labs/test-runner"
-                        :sha     "7284cda41fb9edc0f3bc6b6185cfb7138fc8a023"}}
-                      :jvm-opts ["-Dclojure.main.report=stderr"]
-                      :main-opts ["-m" "cognitect.test-runner"]}
-           :test     {:extra-deps
-                      {babashka/babashka.curl {:mvn/version "0.1.2"}
-                       com.brunobonacci/mulog {:mvn/version "0.9.0"}
-                       com.gfredericks/test.chuck {:mvn/version "0.2.14"}
-                       nu.validator/validator {:mvn/version "20.7.2"}
-                       nubank/matcher-combinators {:mvn/version "3.10.0"}
-                       org.clojure/test.check {:mvn/version "1.1.1"}
-                       org.scicloj/kindly {:mvn/version "4-beta18"}
-                       org.scicloj/kindly-render {:mvn/version "0.1.5-alpha"}
-                       site.fabricate/manual
-                       {:git/url "https://github.com/fabricate-site/manual.git"
-                        :sha     "0285311b5517b806dca43360235bc0fff4970728"}}
-                      :extra-paths ["test"]
-                      :resource-paths ["test-resources"]}
+{:aliases {:runner
+           {:exec-args
+            {:excludes [:performance] #_#_:patterns ["^(?!.*performance).*$"]}
+            :exec-fn cognitect.test-runner.api/test
+            :extra-deps {io.github.cognitect-labs/test-runner
+                         {:git/url
+                          "https://github.com/cognitect-labs/test-runner"
+                          :sha "7284cda41fb9edc0f3bc6b6185cfb7138fc8a023"}}
+            :jvm-opts ["-Dclojure.main.report=stderr"
+                       "-Dclojure.context=cli.test"]
+            :main-opts ["-m" "cognitect.test-runner"]}
+           :test {:extra-deps
+                  {babashka/babashka.curl {:mvn/version "0.1.2"}
+                   com.brunobonacci/mulog {:mvn/version "0.9.0"}
+                   com.gfredericks/test.chuck {:mvn/version "0.2.14"}
+                   nu.validator/validator {:mvn/version "20.7.2"}
+                   nubank/matcher-combinators {:mvn/version "3.10.0"}
+                   org.clojure/test.check {:mvn/version "1.1.1"}
+                   org.scicloj/kindly {:mvn/version "4-beta18"}
+                   org.scicloj/kindly-render {:mvn/version "0.1.5-alpha"}
+                   site.fabricate/manual
+                   {:git/url "https://github.com/fabricate-site/manual.git"
+                    :sha     "0285311b5517b806dca43360235bc0fff4970728"}}
+                  :extra-paths ["test"]
+                  :resource-paths ["test-resources"]}
            :validate {:exec-args {:dirs ["docs/"]}
                       :exec-fn   site.fabricate.prototype.check/html}}
- :deps    {babashka/fs             {:mvn/version "0.2.12"}
-           hiccup/hiccup           {:mvn/version "2.0.0-RC2"}
-           instaparse/instaparse   {:mvn/version "1.4.12"}
-           metosin/malli           {:mvn/version "0.17.0"}
-           org.clojure/clojure     {:mvn/version "1.11.3"}
-           org.clojure/data.finger-tree {:mvn/version "0.0.3"}
-           org.scicloj/kindly      {:mvn/version "4-alpha16"}
-           rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}
-           site.fabricate/adorn    {:git/tag "v0.1.131-alpha"
-                                    :git/url
-                                    "https://github.com/fabricate-site/adorn"
-                                    :sha
-                                    "6a9a87959537a71760cd08f8fc2a292ba4957755"}}
- :paths   ["src" "resources"]}
+ :deps
+ {babashka/fs             {:mvn/version "0.2.12"}
+  hiccup/hiccup           {:mvn/version "2.0.0-RC2"}
+  instaparse/instaparse   {:mvn/version "1.4.12"}
+  metosin/malli           {:mvn/version "0.17.0"}
+  org.clojure/clojure     {:mvn/version "1.12.4"}
+  org.clojure/data.finger-tree {:mvn/version "0.0.3"}
+  org.scicloj/kindly      {:mvn/version "4-alpha16"}
+  rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}
+  site.fabricate/adorn    {:git/tag "v0.1.131-alpha"
+                           :git/url "https://github.com/fabricate-site/adorn"
+                           :sha     "6a9a87959537a71760cd08f8fc2a292ba4957755"}}
+ :paths ["src" "resources"]}

--- a/deps.edn
+++ b/deps.edn
@@ -1,40 +1,40 @@
-{:aliases {:runner
-           {:exec-args
-            {:excludes [:performance] #_#_:patterns ["^(?!.*performance).*$"]}
-            :exec-fn cognitect.test-runner.api/test
-            :extra-deps {io.github.cognitect-labs/test-runner
-                         {:git/url
-                          "https://github.com/cognitect-labs/test-runner"
-                          :sha "7284cda41fb9edc0f3bc6b6185cfb7138fc8a023"}}
-            :jvm-opts ["-Dclojure.main.report=stderr"
-                       "-Dclojure.context=cli.test"]
-            :main-opts ["-m" "cognitect.test-runner"]}
-           :test {:extra-deps
-                  {babashka/babashka.curl {:mvn/version "0.1.2"}
-                   com.brunobonacci/mulog {:mvn/version "0.9.0"}
-                   com.gfredericks/test.chuck {:mvn/version "0.2.14"}
-                   nu.validator/validator {:mvn/version "20.7.2"}
-                   nubank/matcher-combinators {:mvn/version "3.10.0"}
-                   org.clojure/test.check {:mvn/version "1.1.1"}
-                   org.scicloj/kindly {:mvn/version "4-beta18"}
-                   org.scicloj/kindly-render {:mvn/version "0.1.5-alpha"}
-                   site.fabricate/manual
-                   {:git/url "https://github.com/fabricate-site/manual.git"
-                    :sha     "0285311b5517b806dca43360235bc0fff4970728"}}
-                  :extra-paths ["test"]
-                  :resource-paths ["test-resources"]}
+{:aliases {:runner   {:exec-args {:excludes [:performance]
+                                  :patterns ["^(?!.*performance).*$"]}
+                      :exec-fn cognitect.test-runner.api/test
+                      :extra-deps
+                      {io.github.cognitect-labs/test-runner
+                       {:git/url "https://github.com/cognitect-labs/test-runner"
+                        :sha     "7284cda41fb9edc0f3bc6b6185cfb7138fc8a023"}}
+                      :jvm-opts ["-Dclojure.main.report=stderr"
+                                 "-Dclojure.context=cli.test"]
+                      :main-opts ["-m" "cognitect.test-runner"]}
+           :test     {:extra-deps
+                      {babashka/babashka.curl {:mvn/version "0.1.2"}
+                       com.brunobonacci/mulog {:mvn/version "0.9.0"}
+                       com.gfredericks/test.chuck {:mvn/version "0.2.14"}
+                       nu.validator/validator {:mvn/version "20.7.2"}
+                       nubank/matcher-combinators {:mvn/version "3.10.0"}
+                       org.clojure/test.check {:mvn/version "1.1.1"}
+                       org.scicloj/kindly {:mvn/version "4-beta18"}
+                       org.scicloj/kindly-render {:mvn/version "0.1.5-alpha"}
+                       site.fabricate/manual
+                       {:git/url "https://github.com/fabricate-site/manual.git"
+                        :sha     "0285311b5517b806dca43360235bc0fff4970728"}}
+                      :extra-paths ["test"]
+                      :resource-paths ["test-resources"]}
            :validate {:exec-args {:dirs ["docs/"]}
                       :exec-fn   site.fabricate.prototype.check/html}}
- :deps
- {babashka/fs             {:mvn/version "0.2.12"}
-  hiccup/hiccup           {:mvn/version "2.0.0-RC2"}
-  instaparse/instaparse   {:mvn/version "1.4.12"}
-  metosin/malli           {:mvn/version "0.17.0"}
-  org.clojure/clojure     {:mvn/version "1.12.4"}
-  org.clojure/data.finger-tree {:mvn/version "0.0.3"}
-  org.scicloj/kindly      {:mvn/version "4-alpha16"}
-  rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}
-  site.fabricate/adorn    {:git/tag "v0.1.131-alpha"
-                           :git/url "https://github.com/fabricate-site/adorn"
-                           :sha     "6a9a87959537a71760cd08f8fc2a292ba4957755"}}
- :paths ["src" "resources"]}
+ :deps    {babashka/fs             {:mvn/version "0.2.12"}
+           hiccup/hiccup           {:mvn/version "2.0.0-RC2"}
+           instaparse/instaparse   {:mvn/version "1.4.12"}
+           metosin/malli           {:mvn/version "0.17.0"}
+           org.clojure/clojure     {:mvn/version "1.12.4"}
+           org.clojure/data.finger-tree {:mvn/version "0.0.3"}
+           org.scicloj/kindly      {:mvn/version "4-alpha16"}
+           rewrite-clj/rewrite-clj {:mvn/version "1.1.47"}
+           site.fabricate/adorn    {:git/tag "v0.1.131-alpha"
+                                    :git/url
+                                    "https://github.com/fabricate-site/adorn"
+                                    :sha
+                                    "6a9a87959537a71760cd08f8fc2a292ba4957755"}}
+ :paths   ["src" "resources"]}

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
                        site.fabricate/manual
                        {:git/url "https://github.com/fabricate-site/manual.git"
                         :sha     "0285311b5517b806dca43360235bc0fff4970728"}}
-                      :extra-paths ["test"]
+                      :extra-paths ["dev" "test"]
                       :resource-paths ["test-resources"]}
            :validate {:exec-args {:dirs ["docs/"]}
                       :exec-fn   site.fabricate.prototype.check/html}}

--- a/dev/site/fabricate/dev/html.clj
+++ b/dev/site/fabricate/dev/html.clj
@@ -1,6 +1,8 @@
 (ns site.fabricate.dev.html
   "Dev-time checks for HTML. Requires the optional `nu.validator` library (see the :dev alias in deps.edn)"
-  (:require [clojure.data.json :as json])
+  (:require [clojure.data.json :as json]
+            [malli.core :as m]
+            [malli.util :as mu])
   (:import [nu.validator.validation SimpleDocumentValidator]
            [nu.validator.client EmbeddedValidator]
            [java.io ByteArrayInputStream]))
@@ -17,3 +19,63 @@
     (try (let [validator-output (.validate html-validator html-input-stream)]
            (if (empty? validator-output) {} (json/read-str validator-output)))
          (catch Exception e (Throwable->map e)))))
+
+(def ignored-warnings
+  "A set of warning messages to ignore due to outdated validation rules in nu.validator"
+  {:html/dl-child-div
+   (m/schema
+    [:re
+     #"Element “dt” not allowed as child of element “div” in this context."])
+   :html/heading-levels (m/schema [:re #"The heading .* skipping \d heading"])
+   :css/layer (m/schema [:re #"CSS.*layer"])
+   :css/subgrid (m/schema [:re #"CSS.*subgrid"])
+   :css/any (m/schema [:re #"CSS.*"])})
+
+(defn- debug-error-msg [v _] (let [error-str (:value v)] error-str))
+
+(def IgnorableErrorMessage
+  (m/schema [:map ["type" [:= "error"]]
+             ["message"
+              [:and {:error/fn debug-error-msg} :string
+               ;; a string that only matches one of the 'ignored errors'
+               (into [:or]
+                     (map
+                      #(mu/update-properties % assoc :error/fn debug-error-msg))
+                     (vals ignored-warnings))]]]))
+
+(def ValidHTMLOutput
+  (m/schema
+   [:map {:description "parsed JSON output of nu.validator HTML/CSS validation"}
+    ["messages"
+     [:*
+      [:or
+       ;; info - warning is also safe to ignore
+       [:map ["message" :string] ["type" [:= "info"]]
+        ["subType" {:optional true} [:= "warning"]]]
+       [:ref #'IgnorableErrorMessage]]]]]))
+
+(comment
+  (m/validate [:not [:re #"CSS"]] "HTML lacks required <head> elems")
+  (m/explain (into [:and {:error/fn debug-error-msg} :string]
+                   (map #(conj [:not] %))
+                   (vals ignored-warnings))
+             "CSS unrecognized @layer")
+  (m/validate (into [:and {:error/fn debug-error-msg} :string]
+                    (map #(conj [:not] %))
+                    (vals ignored-warnings))
+              "HTML lacks required head elem")
+  (m/validate (into [:and {:error/fn debug-error-msg} :string]
+                    (map #(conj [:not] %))
+                    (vals ignored-warnings))
+              "CSS @layer")
+  (m/validate (into [:and {:error/fn debug-error-msg} :string]
+                    (map #(conj [:not] %))
+                    (vals ignored-warnings))
+              "HTML lacks required <head> elems"))
+
+(def ValidHTMLStrictOutput
+  (m/schema
+   [:map
+    {:description
+     "schema for parsed valid JSON output of nu.validator HTML/CSS validation. Strict validation: will not match if any errors are returned in the output."}
+    ["messages" [:* [:map ["type" [:enum "info"]] ["message" :string]]]]]))

--- a/dev/site/fabricate/dev/html.clj
+++ b/dev/site/fabricate/dev/html.clj
@@ -2,7 +2,8 @@
   "Dev-time checks for HTML. Requires the optional `nu.validator` library (see the :dev alias in deps.edn)"
   (:require [clojure.data.json :as json]
             [malli.core :as m]
-            [malli.util :as mu])
+            [malli.util :as mu]
+            [clojure.string :as str])
   (:import [nu.validator.validation SimpleDocumentValidator]
            [nu.validator.client EmbeddedValidator]
            [java.io ByteArrayInputStream]))
@@ -20,8 +21,8 @@
            (if (empty? validator-output) {} (json/read-str validator-output)))
          (catch Exception e (Throwable->map e)))))
 
-(def ignored-warnings
-  "A set of warning messages to ignore due to outdated validation rules in nu.validator"
+(def ignored-errors
+  "A set of error messages to ignore due to outdated validation rules in nu.validator"
   {:html/dl-child-div
    (m/schema
     [:re
@@ -34,14 +35,17 @@
 (defn- debug-error-msg [v _] (let [error-str (:value v)] error-str))
 
 (def IgnorableErrorMessage
-  (m/schema [:map ["type" [:= "error"]]
-             ["message"
-              [:and {:error/fn debug-error-msg} :string
-               ;; a string that only matches one of the 'ignored errors'
-               (into [:or]
-                     (map
-                      #(mu/update-properties % assoc :error/fn debug-error-msg))
-                     (vals ignored-warnings))]]]))
+  (m/schema
+   [:map ["type" [:= "error"]]
+    ["message"
+     [:re
+      {:error/fn      debug-error-msg
+       :error/message "Unhandled error in nu.validator output"}
+      ;; a string that only matches one of the 'ignored errors'
+      (re-pattern (str/join "|" (map #(last (m/form %)) (vals ignored-errors))))
+      #_(into [:or]
+              (map #(mu/update-properties % assoc :error/fn debug-error-msg))
+              (vals ignored-errors))]]]))
 
 (def ValidHTMLOutput
   (m/schema

--- a/dev/site/fabricate/dev/html.clj
+++ b/dev/site/fabricate/dev/html.clj
@@ -1,0 +1,19 @@
+(ns site.fabricate.dev.html
+  "Dev-time checks for HTML. Requires the optional `nu.validator` library (see the :dev alias in deps.edn)"
+  (:require [clojure.data.json :as json])
+  (:import [nu.validator.validation SimpleDocumentValidator]
+           [nu.validator.client EmbeddedValidator]
+           [java.io ByteArrayInputStream]))
+
+
+(def html-validator
+  (doto (EmbeddedValidator.)
+    (.setOutputFormat nu.validator.client.EmbeddedValidator$OutputFormat/JSON)))
+
+(defn validate-html-string
+  "Returns any warnings or errors from the HTML string as a sequence of parsed JSON maps."
+  [html-string]
+  (let [html-input-stream (ByteArrayInputStream. (.getBytes html-string))]
+    (try (let [validator-output (.validate html-validator html-input-stream)]
+           (if (empty? validator-output) {} (json/read-str validator-output)))
+         (catch Exception e (Throwable->map e)))))

--- a/src/site/fabricate/api.clj
+++ b/src/site/fabricate/api.clj
@@ -159,7 +159,7 @@ One source may produce multiple entries."
 (defmulti collect
   "Generate the input entries from a source."
   {:malli/schema (:malli/schema (meta #'collect-dispatch))}
-  collect-dispatch)
+  #'collect-dispatch)
 
 (def site-schema
   "Malli schema describing the contents of a Fabricate site.
@@ -224,7 +224,7 @@ A site is the primary map passed between the 3 core API functions: plan!, assemb
 (defmulti build
   "Generate structured (EDN) document content for an entry from a source format. Takes an entry and returns a document (entry)."
   {:malli/schema (:malli/schema (meta #'build-dispatch))}
-  build-dispatch)
+  #'build-dispatch)
 
 ;; if no build method is implemented for this entry, just pass it through
 ;; unaltered
@@ -267,7 +267,7 @@ A site is the primary map passed between the 3 core API functions: plan!, assemb
    {:source (URI. "https://www.merriam-webster.com/dictionary/produce")
     :definition
     "to make available for public exhibition or dissemination; to cause to have existence or to happen; to give being, form, or shape to; to compose, create, or bring out by intellectual or physical effort; to bear, make, or yield something"}}
-  produce-dispatch)
+  #'produce-dispatch)
 
 (defmethod produce! :default [entry _opts] entry)
 
@@ -311,7 +311,7 @@ A site is the primary map passed between the 3 core API functions: plan!, assemb
 (defmulti display-form
   "Multimethod to convert a Kindly form into an output format. Dispatches on the kindly kind and the output format."
   {#_:malli/schema}
-  display-form-dispatch)
+  #'display-form-dispatch)
 
 
 (comment

--- a/src/site/fabricate/api.clj
+++ b/src/site/fabricate/api.clj
@@ -305,10 +305,8 @@ A site is the primary map passed between the 3 core API functions: plan!, assemb
 (defn display-form-dispatch
   "Dispatch for display-form multimethod."
   {:private true}
-  ([form
-    {:keys [site.fabricate.page/format] :or {format :hiccup/html} :as opts}]
-   [(:kind form) format])
-  ([form] (display-form-dispatch form {})))
+  [{:keys [site.fabricate.page/format kind] :or {format :hiccup/html} :as form}]
+  (let [kind (or kind (:kindly/kind form))] [kind format]))
 
 (defmulti display-form
   "Multimethod to convert a Kindly form into an output format. Dispatches on the kindly kind and the output format."
@@ -338,10 +336,17 @@ A site is the primary map passed between the 3 core API functions: plan!, assemb
                              (get-in form [:kindly/options :hide-code] true)))
          form-code   (when-not hide-code (or (:form form) (:code form)))
          page-format (or (:site.fabricate.page/format options)
-                         (:site.fabricate.page/format form))]
+                         (:site.fabricate.page/format form))
+         form        (if-not (contains? form :site.fabricate.page/format)
+                       (assoc form
+                              :site.fabricate.page/format
+                              (:site.fabricate.page/format options
+                                                           :hiccup/html))
+                       form)]
      (case [hide-code hide-value]
        [true true]   nil
-       [false true]  (display-form form options)
-       [true false]  (display-form {:kind :code :value form-code} options)
-       [false false] (list (display-form {:kind :code :value form-code} options)
-                           (display-form form options))))))
+       [false true]  (display-form form)
+       [true false]  (display-form {:kind :code :value form-code})
+       [false false] (list (display-form {:kind :code :value form-code})
+                           (display-form form)))))
+  ([form] (render-form form {})))

--- a/src/site/fabricate/api.clj
+++ b/src/site/fabricate/api.clj
@@ -330,7 +330,9 @@ A site is the primary map passed between the 3 core API functions: plan!, assemb
   {:malli/schema (m/schema [:-> site.fabricate.prototype.kindly/Form :map
                             :any])}
   ([form options]
-   (let [hide-value  (true? (get-in form [:kindly/options :hide-value] false))
+   (let [hide-value  (true? (or
+                             (:kindly/hide-value form)
+                             (get-in form [:kindly/options :hide-value] false)))
          hide-code   (true? (or
                              (:kindly/hide-code form)
                              (get-in form [:kindly/options :hide-code] true)))

--- a/src/site/fabricate/api.clj
+++ b/src/site/fabricate/api.clj
@@ -345,8 +345,8 @@ A site is the primary map passed between the 3 core API functions: plan!, assemb
                        form)]
      (case [hide-code hide-value]
        [true true]   nil
-       [false true]  (display-form form)
-       [true false]  (display-form {:kind :code :value form-code})
+       [true false]  (display-form form)
+       [false true]  (display-form {:kind :code :value form-code})
        [false false] (list (display-form {:kind :code :value form-code})
                            (display-form form)))))
   ([form] (render-form form {})))

--- a/src/site/fabricate/prototype/document/clojure.clj
+++ b/src/site/fabricate/prototype/document/clojure.clj
@@ -298,6 +298,8 @@ If passed a file or string path pointing to an existing file, will read from the
                                          (count (trailing-newlines
                                                  prev-element))))
                                 :break
+                                ;; TODO: verify this
+                                (nil? prev-element) :break
                                 (vector? prev-element) (get-element-type
                                                         prev-element))
         next-form-type    (cond (:clojure/uneval next-form) :uneval
@@ -312,6 +314,8 @@ If passed a file or string path pointing to an existing file, will read from the
                                 :default (throw (ex-info "Unmatched form type"
                                                          {:clojure/form
                                                           next-form})))]
+    (when (nil? prev-element-type)
+      (throw (ex-info "nil element type" {:prev prev-element :next next-form})))
     (case [prev-element-type next-form-type]
       [:break :comment]       (list (trim-newlines prev-element)
                                     (new-paragraph next-form))

--- a/src/site/fabricate/prototype/document/fabricate.clj
+++ b/src/site/fabricate/prototype/document/fabricate.clj
@@ -16,9 +16,11 @@
                                                       (meta evaluated-page))]
                                                ;; TODO: better handling of
                                                ;; unbound metadata vars
-                                               (if (map? m) m {})))]
-    (with-meta (into [:article
-                      {:lang  "en-us"
-                       :title (:site.fabricate.page/title page-metadata)}]
-                     (hiccup/parse-paragraphs evaluated-page))
-               page-metadata)))
+                                               (if (map? m) m {})))
+        page-title     (or (:site.fabricate.page/title page-metadata)
+                           (:site.fabricate.document/title page-metadata)
+                           (:title page-metadata))]
+    (with-meta
+      (into [:article {:lang "en-us" :title page-title}]
+            (hiccup/parse-paragraphs evaluated-page))
+      (assoc page-metadata :site.fabricate.document/title page-title))))

--- a/src/site/fabricate/prototype/eval.clj
+++ b/src/site/fabricate/prototype/eval.clj
@@ -18,6 +18,10 @@
 
 ;; TODO: should all the schemas live in... the schema namespace?
 
+(def ^:dynamic *default-kind*
+  "Default kind keyword - added if not specified in the form itself. "
+  :hiccup)
+
 (def Parsed-Form
   "A Kindly form that has been parsed but not evaluated, so lacks a :value entry."
   (-> site.fabricate.prototype.kindly/Form
@@ -57,20 +61,30 @@
 (defn eval-form
   "Evaluate the form in the given Map."
   {:malli/schema (m/schema [:-> Parsed-Form Evaluated-Form])}
-  [{:keys [form value ns] :as form-map}]
-  (if (contains? form-map :value)
-    form-map
-    (try (let [result (binding [*ns* (or ns *ns*)] (eval form))]
-           (cond (instance? IReference result)
-                 (let [result-meta     (meta result)
-                       new-result-meta (-> form-map
-                                           (set/rename-keys
-                                            {:file/start-line   :line
-                                             :file/start-column :column})
-                                           (select-keys [:ns :file :line
-                                                         :column]))]
-                   (alter-meta! result merge new-result-meta)))
-           (merge form-map
-                  {:value result}
-                  (when (meta result) {:meta (meta result)})))
-         (catch Exception e (assoc form-map :error (Throwable->map e))))))
+  [{:keys [kind form value ns code]
+    :or   {kind *default-kind* code (pr-str form)}
+    :as   form-map}]
+  (let [code (or code (pr-str form))]
+    (if (contains? form-map :value)
+      form-map
+      (try (let [result (binding [*ns* (or ns *ns*)] (eval form))]
+             (cond (instance? IReference result)
+                   (let [result-meta     (meta result)
+                         new-result-meta (-> form-map
+                                             (set/rename-keys
+                                              {:file/start-line   :line
+                                               :file/start-column :column})
+                                             (select-keys [:ns :file :line
+                                                           :column]))]
+                     (alter-meta! result merge new-result-meta)))
+             (merge form-map
+                    {:value result :kind kind :code code}
+                    (when (meta result) {:meta (meta result)})))
+           (catch Exception e
+             ;; treat errors simply as a different kind of evaluation
+             ;; result
+             (assoc form-map
+                    :error (Throwable->map e)
+                    :kind  :fabricate/error
+                    :code  code
+                    :value (Throwable->map e)))))))

--- a/src/site/fabricate/prototype/page.clj
+++ b/src/site/fabricate/prototype/page.clj
@@ -17,20 +17,16 @@
 
 ;; TODO: figure out how to use adorn to render nested kinds
 (defmethod api/display-form [:code :hiccup/html]
-  ([form _opts]
-   [:pre {:class "clojure-block" :data-kind (str (name (:kind form)))}
-    [:code {:class "language-clojure"} (adorn/clj->hiccup (:value form))]])
-  ([form] (api/display-form form {})))
+  [form]
+  [:pre {:class "clojure-block" :data-kind (str (name (:kind form)))}
+   [:code {:class "language-clojure"} (adorn/clj->hiccup (:value form))]])
 
-(defmethod api/display-form [:hiccup :hiccup/html]
-  ([form _opts] (:value form))
-  ([form] (api/display-form form {})))
+(defmethod api/display-form [:hiccup :hiccup/html] [form] (:value form))
 
 (defmethod api/display-form [:edn :hiccup/html]
-  ([form _opts]
-   [:pre {:class "clojure-block" :data-kind (str (name (:kind form)))}
-    [:code {:class "language-clojure"} (adorn/clj->hiccup (:value form))]])
-  ([form] (api/display-form form {})))
+  [form]
+  [:pre {:class "clojure-block" :data-kind (str (name (:kind form)))}
+   [:code {:class "language-clojure"} (adorn/clj->hiccup (:value form))]])
 
 
 (comment

--- a/src/site/fabricate/prototype/page/hiccup.clj
+++ b/src/site/fabricate/prototype/page/hiccup.clj
@@ -2,7 +2,12 @@
   "Default API methods for converting Hiccup documents into pages."
   (:require [hiccup2.core :as hiccup]
             [hiccup.page :as hiccup-page]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [clojure.walk :as walk]
+            [site.fabricate.prototype.kindly :as kindly]
+            [site.fabricate.prototype.eval :as eval]
+            [malli.core :as m]
+            [site.fabricate.api :as api]))
 
 (def css-reset
   "CSS reset for Fabricate pages"
@@ -16,6 +21,15 @@
          {:name "viewport" :content "width=device-width, initial-scale=1.0"}]
         [:style css-reset]))
 
+(def kindly-map?
+  "Returns true if the value matches the schema for an evaluated Kindly form map"
+  (m/validator eval/Evaluated-Form))
+
+(defn render-all-forms
+  "Walk all the forms in the given page data and render them."
+  [page-data]
+  (walk/postwalk (fn display? [v] (if (kindly-map? v) (api/render-form v)))))
+
 ;; defaults
 (defn entry->hiccup-body
   "Generate a HTML <body> Hiccup element from the entry."
@@ -27,7 +41,7 @@
   "Generate a HTML <head> Hiccup element from the entry."
   ([{doc-title :site.fabricate.document/title :as entry} opts]
    [:head [:title doc-title] [:meta {:charset "utf-8"}]
-    [:meta {:http-equiv "X-UA-Compatible" :content "IE-edge"}]
+    [:meta {:http-equiv "X-UA-Compatible" :content "IE=edge"}]
     [:meta {:name "viewport" :content "width=device-width, initial-scale=1.0"}]
     [:style css-reset]])
   ([entry] (entry->hiccup-head entry {})))

--- a/src/site/fabricate/prototype/properties.clj
+++ b/src/site/fabricate/prototype/properties.clj
@@ -1,0 +1,125 @@
+(ns site.fabricate.prototype.properties
+  "Namespace defining checks and properties that should hold of each entry."
+  (:require [clojure.test :as t]
+            [babashka.fs :as fs]
+            [malli.core :as m]
+            [malli.util :as mu]
+            [malli.error :as me]
+            [malli.registry :as mr]
+            [site.fabricate.prototype.eval :as eval]
+            [matcher-combinators.matchers :as match]
+            [matcher-combinators.test]))
+
+;; (defn dir-exists? [_] false)
+;; (defn file-exists? [_] false)
+;; (defn absolute-path? [_] false)
+;; (defn valid-config? [_] false)
+;; (defn source-parses? [_] false)
+;; (defn unexpected-errors? [_] false)
+;; (defn valid-kindly-hiccup? [_] false)
+;; (defn no-kindly-maps? [_] false)
+;; (defn all-links-resolve? [_] false)
+;; (defn has-title? [_] false)
+
+(def FileExists
+  "schema for a file that exists"
+  (m/schema [:fn {:error/fn (fn [v _] (str (:value v) " should exist"))}
+             fs/exists?]))
+(def Directory
+  "schema for a directory"
+  (m/schema [:fn
+             {:error/message "should be directory"
+              :error/fn      (fn [{:keys [value]} _]
+                               (str value " should be directory"))}
+             fs/directory?]))
+(def AbsolutePath
+  "schema for absolute path"
+  (m/schema [:fn
+             {:error/message "should be absolute"
+              :error/fn      (fn [v _] (str (:value v) " should be absolute"))}
+             fs/absolute?]))
+(def AbsoluteFile
+  "schema for absolute file path with existing file"
+  (m/schema [:and
+             {:description "existing file found at absolute path"
+              :error/fn    (fn [v _]
+                             (str (:value v)
+                                  " should exist at an absolute path"))}
+             [:ref #'FileExists] [:ref #'AbsolutePath]]))
+(def AbsoluteDirectory
+  "schema for absolute directory that exists"
+  (m/schema [:and
+             {:description "absolute directory that exists"
+              :error/fn    (fn [v _]
+                             (str (:value _)
+                                  " should exist at an absolute path"))}
+             #'Directory #'AbsolutePath]))
+
+(def CollectedEntry
+  "schema for Fabricate entry returned from site.fabricate.api/collect"
+  (m/schema [:map
+             {:title "Collected entry"
+              :description
+              "Fabricate entry returned from site.fabricate.api/collect"}
+             [:site.fabricate.source/location #'AbsoluteFile]
+             [:site.fabricate.source/directory #'AbsoluteDirectory]]))
+
+(def BuiltEntry
+  "schema for Fabricate entry returned from site.fabricate.api/build"
+  (mu/merge CollectedEntry
+            [:map
+             {:title "Built entry"
+              :description
+              "Fabricate entry returned from site.fabricate.api/build"}
+             [:site.fabricate.document/title :string]
+             [:site.fabricate.document/data :any]]))
+
+(def ProducedEntry
+  "schema for Fabricate entry returned from site.fabricate.api/produce!"
+  nil)
+
+(def evaluated-kindly-map?
+  "returns true if the value is an evaluated Kindly map."
+  (m/validator eval/Evaluated-Form))
+
+(defn classify-render-output
+  "Determine whether the render output has the expected components based on Kindly metadata"
+  [{:keys [kind value kindly/hide-value kindly/hide-code] :as form} output]
+  (cond (and hide-code hide-value (some? output)) :unexpected-output
+        (and (nil? output) (some? value) (not hide-value))
+        :unexpected-nil-output
+        (evaluated-kindly-map? output) :kindly-form
+        :else :ok))
+
+(def ^:private render-error-messages
+  {:unexpected-output
+   "render returns output when hide-code and hide-value are both true"
+   :unexpected-nil-output
+   "render returns nil when value exists and is not hidden"
+   :kindly-form "render returns kindly form instead of rendered value"
+   :ok "render returns rendered value"})
+
+(defn- valid-render-output?
+  [[[form] output]]
+  (= :ok (classify-render-output form output)))
+
+(defn- render-output-error-fn
+  [[[form] output]]
+  (get render-error-messages (classify-render-output form output)))
+
+(def =>RenderForm
+  "function schema for site.fabricate.api/render-form output"
+  (m/schema [:=> [:cat eval/Evaluated-Form :map] :any
+             [:fn {:error/fn render-output-error-fn} valid-render-output?]]))
+
+(comment
+  (me/humanize (m/explain AbsoluteDirectory
+                          (fs/file "/path/to/non-existent/dir")))
+  (fs/directory? (fs/file "./src"))
+  (me/humanize (m/explain [:fn
+                           {:title         "File exists"
+                            :error/message "file should exist"
+                            :error/fn      (fn [{:keys [value]} _]
+                                             (str value " should exist"))}
+                           fs/exists?]
+                          "./path/to-nonexistent-file.txt")))

--- a/src/site/fabricate/prototype/properties.clj
+++ b/src/site/fabricate/prototype/properties.clj
@@ -7,6 +7,7 @@
             [malli.error :as me]
             [malli.registry :as mr]
             [site.fabricate.prototype.eval :as eval]
+            [site.fabricate.prototype.html :as html]
             [matcher-combinators.matchers :as match]
             [matcher-combinators.test]))
 
@@ -64,6 +65,16 @@
              [:site.fabricate.source/location #'AbsoluteFile]
              [:site.fabricate.source/directory #'AbsoluteDirectory]]))
 
+#_(def FabricateHiccup
+    (m/schema [:schema
+               (assoc-in (m/properties html/element)
+                [:registry ::fabricate-hiccup]
+                [:cat :keyword [:? :map]
+                 [:*
+                  [:or [:schema [:ref ::html/element]]
+                   (m/schema eval/Evaluated-Form)
+                   [:schema [:ref ::fabricate-hiccup]]]]]) ::fabricate-hiccup]))
+
 (def BuiltEntry
   "schema for Fabricate entry returned from site.fabricate.api/build"
   (mu/merge CollectedEntry
@@ -74,9 +85,24 @@
              [:site.fabricate.document/title :string]
              [:site.fabricate.document/data :any]]))
 
+(def FabricateHiccupEntry
+  "schema for Fabricate entry consisting of Hiccup data with embedded Kindly maps"
+  (mu/merge BuiltEntry
+            [:map
+             {:title "Built Hiccup entry"
+              :description
+              "Fabricate Hiccup entry returned from site.fabricate.api/build"}
+             [:site.fabricate.document/data [:vector :any]
+              #_[:ref #'FabricateHiccup]]]))
+
 (def ProducedEntry
   "schema for Fabricate entry returned from site.fabricate.api/produce!"
-  nil)
+  (mu/merge BuiltEntry
+            [:map
+             {:title "Produced entry"
+              :description
+              "Fabricate entry returned from site.fabricate.api/produce"}
+             [:site.fabricate.page/data :any]]))
 
 (def evaluated-kindly-map?
   "returns true if the value is an evaluated Kindly map."
@@ -108,7 +134,7 @@
   (get render-error-messages (classify-render-output form output)))
 
 (def =>RenderForm
-  "function schema for site.fabricate.api/render-form output"
+  "function schema for site.fabricate.api/render-form implementations"
   (m/schema [:=> [:cat eval/Evaluated-Form :map] :any
              [:fn {:error/fn render-output-error-fn} valid-render-output?]]))
 

--- a/src/site/fabricate/prototype/schema.clj
+++ b/src/site/fabricate/prototype/schema.clj
@@ -14,6 +14,7 @@
 (mr/set-default-registry! (mr/composite-registry (m/default-schemas)
                                                  (mt/schemas)
                                                  (mu/schemas)
+                                                 (mr/var-registry)
                                                  (mr/mutable-registry
                                                   registry)))
 

--- a/test/site/fabricate/api_test.clj
+++ b/test/site/fabricate/api_test.clj
@@ -64,7 +64,26 @@
                  :value)))
     (t/is (map? (-> {:code "(inc \"a\")" :form '(inc "a") :kind :code}
                     (api/eval-form)
-                    :error)))))
+                    :error))))
+  (t/testing "form rendering"
+    (let
+      [form
+       {:kindly/hide-code true
+        :site.fabricate.page/format :hiccup/html
+        :value [:pre {:class "shell"}
+                [:code "clojure -M:fabricate:clojure.main/main"]]
+        :kindly/hide-value false
+        :kind :hiccup
+        :code
+        "[:pre {:class \"shell\"} [:code  \"clojure -M:fabricate:clojure.main/main\"]]"
+        :form [:pre {:class "shell"}
+               [:code "clojure -M:fabricate:clojure.main/main"]]}]
+      (t/is
+       (apply =
+              (map #(update-in % [1] dissoc :data-kind :data-kindly-hide-code)
+                   [(:value form) (api/display-form form)
+                    (api/render-form form)]))
+       "Forms with :hide-value false and :hide-code true and :kind :hiccup should always be the :value"))))
 
 
 

--- a/test/site/fabricate/api_test.clj
+++ b/test/site/fabricate/api_test.clj
@@ -83,7 +83,10 @@
               (map #(update-in % [1] dissoc :data-kind :data-kindly-hide-code)
                    [(:value form) (api/display-form form)
                     (api/render-form form)]))
-       "Forms with :hide-value false and :hide-code true and :kind :hiccup should always be the :value"))))
+       "Forms with :kindly/hide-value false and :kindly/hide-code true and :kind :hiccup should always be the :value")
+      (t/is
+       (nil? (api/render-form (assoc form :kindly/hide-value true)))
+       "Forms with :kindly/hide-value and :kindly/hide-code should return nil"))))
 
 
 

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -13,6 +13,7 @@
             [site.fabricate.prototype.kindly :as kindly]
             [site.fabricate.prototype.document.clojure :as clj]
             [site.fabricate.prototype.page.hiccup :as hiccup]
+            [site.fabricate.prototype.page :as page]
             [site.fabricate.prototype.hiccup :as prototype.hiccup]
             [site.fabricate.prototype.document.fabricate :as fab]
             [site.fabricate.prototype.test-utils :as test-utils]
@@ -209,22 +210,38 @@
 
 (defn process-hiccup-form
   [{:keys [kind value] :as form}]
-  (let [data-attrs (with-keys form key-lookup)]
-    (chassis/apply-normalized (fn add-data-attrs [tag attrs contents]
-                                (into [tag (merge attrs data-attrs)] contents))
-                              value)))
+  #_(when (nil? value)
+      (throw (ex-info "Hiccup element should not be nil" {:kindly-map form})))
+  (when value
+    (let [data-attrs (with-keys form key-lookup)]
+      (chassis/apply-normalized (fn add-data-attrs [tag attrs contents]
+                                  (into [tag (merge attrs data-attrs)]
+                                        contents))
+                                value))))
 
 (def kindly-map? (m/validator eval/Evaluated-Form))
 
+;; pre and post assertions for process-kinds
+;; 1. count the number of nil :values in the kindly forms + ensure the
+;; post-walked form has the same number of nils
+;; 2.
+
 (defn process-kinds
   [form page-format]
-  (walk/postwalk (fn [v]
-                   (if (kindly-map? v)
-                     (let [output (api/display-form v page-format)]
-                       #_(t/is (not (kindly-map? output))
-                               "All kindly maps should be transformed")
-                       output)))
-                 form))
+  (walk/postwalk
+   (fn [v]
+     (if (kindly-map? v)
+       (let [output (api/render-form
+                     (assoc v :site.fabricate.page/format page-format))
+             unexpected-nil-output? (and (nil? output) (some? (:value v)))]
+         (when unexpected-nil-output? (pprint/pprint v))
+         (t/is (not unexpected-nil-output?)
+               "Non-nil values should not be returned as nil after rendering")
+         (t/is (not (kindly-map? output))
+               "All kindly maps should be transformed")
+         output)
+       v))
+   form))
 
 (def html-validator
   (doto (EmbeddedValidator.)
@@ -246,31 +263,56 @@
   (defmethod api/display-form [:kind/hiccup :chassis/hiccup]
     [form]
     (process-hiccup-form form))
+  (defmethod api/display-form [:hiccup :hiccup/html]
+    [form]
+    (process-hiccup-form form))
+  (defmethod api/display-form [:code :hiccup/html]
+    [form]
+    (process-hiccup-form form))
   (defmethod api/produce! [::hiccup :chassis/hiccup]
-    [entry opts]
-    (let [{:keys [site.fabricate.document/data] :as processed-entry}
-          (update entry
-                  :site.fabricate.document/data
-                  #(process-kinds % :chassis/hiccup))
-          output-hiccup     [chassis/doctype-html5
-                             (hiccup/entry->hiccup-head processed-entry)
-                             (hiccup/entry->hiccup-body processed-entry)]
-          output-html       (chassis/html output-hiccup)
-          validation-result (validate-html-string output-html)]
-      #_(t/is (match? {:site.fabricate.document/title string?} processed-entry)
-              "Each entry should have a title")
-      (t/is (valid-schema? html/element data)
-            "api/produce should produce valid Hiccup elements")
-      (pprint/print-table ["type" "subType" "extract" "message"]
-                          (get validation-result "messages"))
-      (t/is (empty? (into []
-                          (filter #(and (= "error" (get % "type"))
-                                        ;; known bug: current version of
-                                        ;; validator detects CSS layer
-                                        ;; directive as invalid
-                                        (not (re-find #"CSS.*@layer"
-                                                      (get % "message")))))
-                          (get validation-result "messages")))))))
+    [{:keys [site.fabricate.document/title] :as entry} opts]
+    (t/testing (str title)
+      (let [{:keys [site.fabricate.document/data] :as processed-entry}
+            (update entry
+                    :site.fabricate.document/data
+                    #(process-kinds % :chassis/hiccup))
+            output-hiccup     [chassis/doctype-html5
+                               (hiccup/entry->hiccup-head processed-entry)
+                               (hiccup/entry->hiccup-body processed-entry)]
+            output-html       (chassis/html output-hiccup)
+            validation-result (validate-html-string output-html)]
+        #_(t/is (match? {:site.fabricate.document/title string?}
+                        processed-entry)
+                "Each entry should have a title")
+        ;; uncomment this when the schema supports lists/seqs of elements!
+        #_(t/is (valid-schema? html/element data)
+                "api/produce should produce valid Hiccup elements")
+        (pprint/print-table ["type" "subType" "extract" "message"]
+                            (get validation-result "messages"))
+        (t/is (empty? (into []
+                            (filter #(and (= "error" (get % "type"))
+                                          ;; known bug: current version of
+                                          ;; validator detects CSS layer
+                                          ;; directive as invalid
+                                          (not (re-find #"CSS.*@layer"
+                                                        (get % "message")))
+                                          ;; no support for CSS subgrid in
+                                          ;; 2026?
+                                          (not (re-find #"CSS.*subgrid"
+                                                        (get % "message")))))
+                            (get validation-result "messages"))))))))
+
+
+(defn unregister-multimethods!
+  "clean up + unmap test-specific multimethod impls"
+  [site]
+  (run! (partial remove-method api/collect) (keys pattern-formats))
+  (run! (partial remove-method api/build)
+        [[::fabricate ::hiccup] [::clojure ::hiccup]])
+  (run! (partial remove-method api/produce!) [[::hiccup :chassis/hiccup]])
+  (run! (partial remove-method api/display-form)
+        [[:kind/hiccup :chassis/hiccup]])
+  site)
 
 (defn test-site
   [{:keys [site.fabricate.dev.build/setup-tasks site.fabricate.api/options]
@@ -284,12 +326,14 @@
                    (do (->> site-config
                             (#'site.fabricate.api/plan! setup-tasks)
                             (#'site.fabricate.api/assemble assemble-tasks)
-                            (#'site.fabricate.api/construct! []))
+                            (#'site.fabricate.api/construct!
+                             [unregister-multimethods!]))
                        :done)))))
       (t/testing "validity of generated page contents"
                  ;; TODO: validate the Hiccup passed to Chassis during
                  ;; `api/produce!` using the HTML namespace
       ))))
+
 
 (t/deftest sites
   ;; only define the multimethods at runtime
@@ -297,11 +341,4 @@
   (register-build-methods!)
   (register-produce-methods!)
   (if (test-utils/cli-test?) (match-config/enable-abbreviation!))
-  (run! test-site (into [manual-site-config] additional-sites))
-  ;; clean up + unmap test-specific multimethod impls
-  (run! (partial remove-method api/collect) (keys pattern-formats))
-  (run! (partial remove-method api/build)
-        [[::fabricate ::hiccup] [::clojure ::hiccup]])
-  (run! (partial remove-method api/produce!) [[::hiccup :chassis/hiccup]])
-  (run! (partial remove-method api/display-form)
-        [[:kind/hiccup] :chassis/hiccup]))
+  (run! test-site (into [manual-site-config] additional-sites)))

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -7,6 +7,7 @@
             [site.fabricate.api :as api]
             [site.fabricate.dev.build :as build]
             [site.fabricate.prototype.html :as html]
+            [site.fabricate.prototype.kindly :as kindly]
             [site.fabricate.prototype.document.clojure :as clj]
             [site.fabricate.prototype.document.fabricate :as fab]
             [malli.core :as m]
@@ -88,7 +89,19 @@
   ([] (register-collect-methods! pattern-formats)))
 
 (def entry? (m/validator api/Entry))
-(defn valid-fabricate-hiccup? [hiccup-data] vector?)
+
+
+(def fabricate-hiccup-schema
+  (m/schema [:schema
+             (assoc-in (m/properties html/element)
+              [:registry ::fabricate-hiccup]
+              [:cat :keyword [:? :map]
+               [:*
+                [:or [:schema [:ref ::html/element]] (m/schema kindly/Form)
+                 [:schema [:ref ::fabricate-hiccup]]]]]) ::fabricate-hiccup]))
+
+(def valid-fabricate-hiccup? (m/validator fabricate-hiccup-schema))
+
 (defn valid-output-hiccup? [hiccup-data] (html/element? hiccup-data))
 
 (defn build-fabricate

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -255,14 +255,15 @@
         ;; uncomment this when the schema supports lists/seqs of elements!
         #_(t/is (valid-schema? html/element data)
                 "api/produce should produce valid Hiccup elements")
-        (binding [pprint/*print-miser-width*  60
-                  pprint/*print-right-margin* 75]
+        (binding [pprint/*print-miser-width* 60
+                  pprint/*print-right-margin* 75
+                  *print-length* 10
+                  *print-level* 7]
           (pprint/pprint
            (mapv #(select-keys % ["type" "subType" "extract" "message"])
-                 (get validation-result "messages"))))
-        (t/is (valid-schema? html-check/ValidHTMLOutput validation-result))))))
-
-
+                 (get validation-result "messages")))
+          (t/is (valid-schema? html-check/ValidHTMLOutput
+                               validation-result)))))))
 
 (defn unregister-multimethods!
   "clean up + unmap test-specific multimethod impls"

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -260,30 +260,7 @@
           (pprint/pprint
            (mapv #(select-keys % ["type" "subType" "extract" "message"])
                  (get validation-result "messages"))))
-        (t/is
-         (empty?
-          (into
-           []
-           (remove
-            #(or
-              (#{"info" "warning"} (get % "type"))
-              (and
-               (= "error" (get % "type"))
-               (or
-                ;; <dt> within <div> elements within <dl> elements have
-                ;; been valid HTML since 2017 (HTML5.2)
-                (re-find
-                 #"Element “dt” not allowed as child of element “div” in this context."
-                 (get % "message"))
-                (re-find #"skipping \d heading levels" (get % "message"))
-                ;; known bug: current version of
-                ;; validator detects CSS layer
-                ;; directive as invalid
-                (re-find #"CSS.*layer" (get % "message"))
-                ;; no support for CSS subgrid in 2026?
-                (re-find #"CSS.*subgrid" (get % "message"))
-                (re-find #"CSS.*" (get % "message"))))))
-           (get validation-result "messages"))))))))
+        (t/is (valid-schema? html-check/ValidHTMLOutput validation-result))))))
 
 
 

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -32,7 +32,8 @@
 
 (def manual-site-config
   {:site.fabricate.api/options
-   {:site.fabricate.page/publish-dir (fs/create-temp-dir)
+   {:html/debug? false
+    :site.fabricate.page/publish-dir (fs/create-temp-dir)
     :site.fabricate.build-test/setup-tasks
     (drop-last 3 site.fabricate.dev.build/setup-tasks)
     ;; eventually the manual should provide pages to the library
@@ -109,32 +110,34 @@
            results)))))
   ([] (register-collect-methods! pattern-formats)))
 
-
-(def entry? (m/validator api/Entry))
-
-
-(defn debug-entry-error
-  [{:keys [path in value schema] :as error}]
-  (println "Did not match schema")
-  (pprint/pprint schema)
-  (if (test-utils/cli-test?)
-    (binding [*print-length* 5 *print-level* 1] (pprint/pprint value))
-    (binding [*print-length* 20 *print-level* 4] (pprint/pprint value))))
-
-
-(defn valid-output-hiccup? [hiccup-data] (html/element? hiccup-data))
-
 (defn build-fabricate
   "Build and test the entry from a Fabricate template"
-  [entry]
-  {:pre [(t/is (entry? entry))] :post [(t/is (and (entry? %)))]}
-  entry)
+  [{:keys [site.fabricate.source/location site.fabricate.source/file] :as entry}
+   opts]
+  {:pre  [(t/is (valid-schema? props/CollectedEntry entry))]
+   :post [(t/is (valid-schema? props/FabricateHiccupEntry %))]}
+  (let [hiccup-article (fab/entry->hiccup-article entry opts)
+        page-metadata  (meta hiccup-article)]
+    (assoc entry
+           :site.fabricate.document/data  hiccup-article
+           :site.fabricate.document/title (:title page-metadata))))
 
 (defn build-clojure
   "Build and test the entry from a Clojure source"
-  [entry]
-  {:pre [(t/is (entry? entry))] :post [(t/is (and (entry? %)))]}
-  entry)
+  [{:keys [site.fabricate.source/location] :as entry} opts]
+  {:pre  [(t/is (valid-schema? props/CollectedEntry entry))]
+   :post [(t/is (valid-schema? props/FabricateHiccupEntry %))]}
+  (let [data (-> location
+                 clj/read-forms
+                 clj/eval-forms
+                 clj/forms->hiccup)
+        page-metadata (-> data
+                          (get-in [1 :data-clojure-namespace])
+                          (find-ns)
+                          meta)]
+    (-> entry
+        (assoc :site.fabricate.document/data data)
+        (merge page-metadata))))
 
 (defn register-build-methods!
   []
@@ -147,30 +150,10 @@
              :site.fabricate.document/data  hiccup-article
              :site.fabricate.document/title (:title page-metadata))))
   (defmethod api/build [::clojure ::hiccup]
-    [{:keys [site.fabricate.source/location] :as entry} opts]
-    (let [data (-> location
-                   clj/read-forms
-                   clj/eval-forms
-                   clj/forms->hiccup)
-          page-metadata (-> data
-                            (get-in [1 :data-clojure-namespace])
-                            (find-ns)
-                            meta)]
-      (-> entry
-          (assoc :site.fabricate.document/data data)
-          (merge page-metadata)))))
+    [entry opts]
+    (build-clojure entry opts)))
 
-(defn check-hiccup-entries
-  [{:keys [site.fabricate.api/entries] :as site}]
-  (binding [*print-length* (if (test-utils/cli-test?) 5 10)
-            *print-level*  (if (test-utils/cli-test?) 1 5)]
-    (doseq [{:keys [site.fabricate.source/location] :as e} entries]
-      (when (#{::hiccup} (e :site.fabricate.document/format))
-        (t/testing (str "\nentry: " location)
-          (t/is (valid-schema? props/FabricateHiccupEntry e))))))
-  site)
-
-(def assemble-tasks [check-hiccup-entries])
+(def assemble-tasks [])
 
 (def key-lookup
   {:kind        :data-kind
@@ -195,40 +178,20 @@
 
 (def kindly-map? (m/validator eval/Evaluated-Form))
 
-;; TODO: reimplement the post assertions as part of a malli schema
+(defn render-kindly
+  "Render the kindly form into an output format"
+  {:malli/schema props/=>RenderForm}
+  [v]
+  {:post [(t/is (= :ok (props/classify-render-output v %)))]}
+  (api/render-form v))
+
 (defn process-kinds
   [form page-format]
-  (try
-    (walk/postwalk
-     (fn [v]
-       (if (kindly-map? v)
-         (let [{:keys [kind value kindly/hide-code kindly/hide-value] :as v}
-               (assoc v :site.fabricate.page/format page-format)
-               output (api/render-form v)
-               unexpected-nil-output?
-               (and (nil? output) (some? value) (not (:kindly/hide-value v)))
-               unexpected-output (and hide-code hide-value (some? output))]
-           (t/is
-            (not unexpected-output)
-            "Values should not be returned when :kindly/hide-code and :kindly/hide-value are both true")
-           (when unexpected-nil-output? (pprint/pprint v))
-           (t/is
-            (not unexpected-nil-output?)
-            (str
-             "Non-nil values should not be returned as nil after rendering kind "
-             kind
-             " to output format " page-format))
-           (t/is (not (kindly-map? output))
-                 "All kindly maps should be transformed")
-           output)
-         v))
-     form)
-    (catch Exception e
-      (do (println "encountered an error processing form")
-          #_(pprint/pprint form)))))
-
-
-
+  (try (walk/postwalk (fn process? [v] (if (kindly-map? v) (render-kindly v) v))
+                      form)
+       (catch Exception e
+         (do (println "encountered an error processing form")
+             #_(pprint/pprint form)))))
 
 (defn register-produce-methods!
   []
@@ -249,9 +212,6 @@
                                    (catch Exception e
                                      "<<<HTML RENDERING ERROR>>>"))
             validation-result (html-check/validate-html-string output-html)]
-        #_(t/is (match? {:site.fabricate.document/title string?}
-                        processed-entry)
-                "Each entry should have a title")
         ;; uncomment this when the schema supports lists/seqs of elements!
         #_(t/is (valid-schema? html/element data)
                 "api/produce should produce valid Hiccup elements")
@@ -259,9 +219,10 @@
                   pprint/*print-right-margin* 75
                   *print-length* 10
                   *print-level* 7]
-          (pprint/pprint
-           (mapv #(select-keys % ["type" "subType" "extract" "message"])
-                 (get validation-result "messages")))
+          ;; make this configurable, eventually
+          #_(pprint/pprint
+             (mapv #(select-keys % ["type" "subType" "extract" "message"])
+                   (get validation-result "messages")))
           (t/is (valid-schema? html-check/ValidHTMLOutput
                                validation-result)))))))
 

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -280,6 +280,10 @@
   [{:keys [site.fabricate.dev.build/setup-tasks site.fabricate.api/options]
     :or   {setup-tasks []}
     :as   site-config}]
+  ;; only define the multimethods at runtime
+  (register-collect-methods!)
+  (register-build-methods!)
+  (register-produce-methods!)
   (let [{:keys [site.fabricate.source/dir]} options]
     (when (fs/exists? dir)
       (t/testing (str dir ":")
@@ -293,9 +297,5 @@
                        :done))))))))
 
 (t/deftest sites
-  ;; only define the multimethods at runtime
-  (register-collect-methods!)
-  (register-build-methods!)
-  (register-produce-methods!)
   (if (test-utils/cli-test?) (match-config/enable-abbreviation!))
   (run! test-site (into [manual-site-config] additional-sites)))

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -54,42 +54,33 @@
     (mapv path->site-config (str/split test-sites #","))
     []))
 
-(defmethod api/collect (str test-dir "/**/*.fab")
-  [pattern {:keys [site.fabricate.source/dir] :as opts}]
-  (t/testing (str pattern ":")
-    (let [pattern (str (fs/file "**" (fs/file-name pattern)))
-          results (mapv (fn [p]
-                          ;; using namespace-specific formats ensures that
-                          ;; the tests never clash with other default
-                          ;; multimethods
-                          {:site.fabricate.source/format ::fabricate
-                           :site.fabricate.document/format ::hiccup
-                           :site.fabricate.page/format ::hiccup-html
-                           ::api/source pattern
-                           :site.fabricate.source/original-location
-                           (:site.fabricate.source/original-location opts)
-                           :site.fabricate.source/location (fs/file p)})
-                        (fs/glob dir pattern))]
-      (t/is (every? fs/exists? (map :site.fabricate.source/location results))
-            (str "every collected entry should exist"))
-      results)))
+(def pattern-formats
+  {(str test-dir "/**/*.fab") ::fabricate (str test-dir "/**/*.clj") ::clojure})
 
-(defmethod api/collect (str test-dir "/**/*.clj")
-  [pattern {:keys [site.fabricate.source/dir] :as opts}]
-  (t/testing (str pattern ": ")
-    (let [pattern (str (fs/file "**" (fs/file-name pattern)))
-          results (mapv (fn [p]
-                          {:site.fabricate.source/format ::clojure
-                           :site.fabricate.document/format ::hiccup
-                           :site.fabricate.page/format ::hiccup-html
-                           ::api/source pattern
-                           :site.fabricate.source/original-location
-                           (:site.fabricate.source/original-location opts)
-                           :site.fabricate.source/location (fs/file p)})
-                        (fs/glob dir pattern))]
-      (t/is (every? fs/exists? (map :site.fabricate.source/location results))
-            (str "every collected entry should exist"))
-      results)))
+(defn register-collect-methods!
+  ([pattern-formats]
+   (doseq [[pattern fmt] pattern-formats]
+     (defmethod api/collect pattern
+       [pattern {:keys [site.fabricate.source/dir] :as opts}]
+       (t/testing (str pattern ":")
+         (let [pattern (str (fs/file "**" (fs/file-name pattern)))
+               results (mapv (fn [p]
+                               ;; using namespace-specific formats ensures
+                               ;; that the tests never clash with other
+                               ;; default multimethods
+                               {:site.fabricate.source/format fmt
+                                :site.fabricate.document/format ::hiccup
+                                :site.fabricate.page/format ::hiccup-html
+                                ::api/source pattern
+                                :site.fabricate.source/original-location
+                                (:site.fabricate.source/original-location opts)
+                                :site.fabricate.source/location (fs/file p)})
+                             (fs/glob dir pattern))]
+           (t/is (every? fs/exists?
+                         (map :site.fabricate.source/location results))
+                 (str "every collected entry should exist"))
+           results)))))
+  ([] (register-collect-methods! pattern-formats)))
 
 (def entry? (m/validator api/Entry))
 
@@ -125,4 +116,9 @@
                  ;; `api/produce!` using the HTML namespace
       ))))
 
-(t/deftest sites (run! test-site (into [manual-site-config] additional-sites)))
+(t/deftest sites
+  ;; only define the multimethods at runtime
+  (register-collect-methods!)
+  (run! test-site (into [manual-site-config] additional-sites))
+  ;; clean up + unmap test-specific multimethod impls
+  (run! (partial remove-method api/collect) (keys pattern-formats)))

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -3,47 +3,126 @@
             [clojure.string :as str]
             [site.fabricate.api :as api]
             [site.fabricate.dev.build :as build]
+            [site.fabricate.prototype.html :as html]
+            [malli.core :as m]
             [babashka.fs :as fs]
             [clojure.java.io :as io]))
 
 (def manual-site-config
-  {:site.fabricate.page/publish-dir       (fs/create-temp-dir)
-   :site.fabricate.build-test/setup-tasks (drop-last
-                                           3
-                                           site.fabricate.dev.build/setup-tasks)
-   :site.fabricate.source/source-dir
-   ;; eventually the manual should provide pages to the library
-   ;; using resources on the classpath so it can be: (io/resource ...)
-   ;; so these tests run in CI
-   "../fabricate-manual/docs"})
+  {:site.fabricate.api/options
+   {:site.fabricate.page/publish-dir (fs/create-temp-dir)
+    :site.fabricate.build-test/setup-tasks
+    (drop-last 3 site.fabricate.dev.build/setup-tasks)
+    ;; eventually the manual should provide pages to the library
+    ;; using resources on the classpath so it can be: (io/resource ...)
+    ;; so these tests run in CI
+    :site.fabricate.source/dir "../fabricate-manual/docs"
+    :site.fabricate.source/original-location "../fabricate-manual/docs"}})
+
+;; Fabricate's multimethods are flexible enough to allow them to be used in
+;; its own test suite to ensure properties hold about actual sites being built.
+
+(defonce test-dir (fs/create-temp-dir {:prefix "fabricate-test-"}))
 
 (defn path->site-config
   [site-dir]
-  {:site.fabricate/site-name         (str (fs/parent site-dir))
-   :site.fabricate.source/source-dir site-dir})
+  {:site.fabricate.api/options
+   {:site.fabricate/site-name  (str (fs/parent site-dir))
+    :site.fabricate.source/original-location site-dir
+    :site.fabricate.source/dir site-dir}})
+
+
+(defn copy-to-test-dir!
+  "Copies the site's source dir to the test location."
+  [{:keys [site.fabricate.api/options] :as site-config}]
+  ;; https://stackoverflow.com/questions/24834116/how-can-i-get-clojure-pre-post-to-report-their-failing-value
+  {:post [(t/is (fs/exists? (:site.fabricate.source/dir %))
+                "Test directory should be copied successfully")]}
+  (let [dir (:site.fabricate.source/dir options)
+        new-location (fs/file test-dir (fs/file-name dir))]
+    (fs/copy-tree dir new-location {:replace-existing true})
+    (assoc site-config :site.fabricate.source/dir new-location)))
+
+(def setup-tasks [copy-to-test-dir!])
+
+(defn drop-relative-to-parent
+  [f]
+  (apply fs/file (drop 1 (fs/components (fs/file f)))))
 
 (def additional-sites
   (if-let [test-sites (System/getProperty "site.fabricate.build-test.dirs")]
     (mapv path->site-config (str/split test-sites #","))
     []))
 
+(defmethod api/collect (str test-dir "/**/*.fab")
+  [pattern {:keys [site.fabricate.source/dir] :as opts}]
+  (t/testing (str pattern ":")
+    (let [pattern (str (fs/file "**" (fs/file-name pattern)))
+          results (mapv (fn [p]
+                          ;; using namespace-specific formats ensures that
+                          ;; the tests never clash with other default
+                          ;; multimethods
+                          {:site.fabricate.source/format ::fabricate
+                           :site.fabricate.document/format ::hiccup
+                           :site.fabricate.page/format ::hiccup-html
+                           ::api/source pattern
+                           :site.fabricate.source/original-location
+                           (:site.fabricate.source/original-location opts)
+                           :site.fabricate.source/location (fs/file p)})
+                        (fs/glob dir pattern))]
+      (t/is (every? fs/exists? (map :site.fabricate.source/location results))
+            (str "every collected entry should exist"))
+      results)))
+
+(defmethod api/collect (str test-dir "/**/*.clj")
+  [pattern {:keys [site.fabricate.source/dir] :as opts}]
+  (t/testing (str pattern ": ")
+    (let [pattern (str (fs/file "**" (fs/file-name pattern)))
+          results (mapv (fn [p]
+                          {:site.fabricate.source/format ::clojure
+                           :site.fabricate.document/format ::hiccup
+                           :site.fabricate.page/format ::hiccup-html
+                           ::api/source pattern
+                           :site.fabricate.source/original-location
+                           (:site.fabricate.source/original-location opts)
+                           :site.fabricate.source/location (fs/file p)})
+                        (fs/glob dir pattern))]
+      (t/is (every? fs/exists? (map :site.fabricate.source/location results))
+            (str "every collected entry should exist"))
+      results)))
+
+(def entry? (m/validator api/Entry))
+
+(defn valid-fabricate-hiccup? [hiccup-data])
+
+(defn build-fabricate
+  "Build and test the entry from a Fabricate template"
+  [entry]
+  {:pre [(t/is (entry? entry))] :post [(t/is (and (entry? %)))]}
+  entry)
+
+#_(defmethod api/build)
+#_(defmethod api/build)
+
+(defn valid-output-hiccup? [hiccup-data] (html/element? hiccup-data))
+
 (defn test-site
-  [{:keys [site.fabricate.source/source-dir
-           site.fabricate.dev.build/setup-tasks]
+  [{:keys [site.fabricate.dev.build/setup-tasks site.fabricate.api/options]
     :or   {setup-tasks []}
     :as   site-config}]
-  (when (fs/exists? source-dir)
-    (t/testing (str source-dir ":")
-      (t/testing (str "ability to build without errors")
-        (t/is (= :done
-                 (do (->> {:site.fabricate.api/options site-config}
-                          (#'site.fabricate.api/plan! setup-tasks)
-                          (#'site.fabricate.api/assemble [])
-                          (#'site.fabricate.api/construct! []))
-                     :done)))))
-    (t/testing "validity of generated page contents"
-               ;; TODO: validate the Hiccup passed to Chassis during
-               ;; `api/produce!` using the HTML namespace
-    )))
+  (let [{:keys [site.fabricate.source/dir]} options]
+    (when (fs/exists? dir)
+      (t/testing (str dir ":")
+        (t/testing (str "ability to build without errors")
+          (t/is (= :done
+                   (do (->> site-config
+                            (#'site.fabricate.api/plan! setup-tasks)
+                            (#'site.fabricate.api/assemble [])
+                            (#'site.fabricate.api/construct! []))
+                       :done)))))
+      (t/testing "validity of generated page contents"
+                 ;; TODO: validate the Hiccup passed to Chassis during
+                 ;; `api/produce!` using the HTML namespace
+      ))))
 
 (t/deftest sites (run! test-site (into [manual-site-config] additional-sites)))

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -19,6 +19,7 @@
             [site.fabricate.prototype.test-utils :as test-utils]
             [dev.onionpancakes.chassis.core :as chassis]
             [malli.core :as m]
+            [malli.dev.pretty :as mp]
             [malli.error :as me]
             [babashka.fs :as fs]
             [clojure.java.io :as io]
@@ -126,16 +127,18 @@
     (binding [*print-length* 5 *print-level* 1] (pprint/pprint value))
     (binding [*print-length* 20 *print-level* 4] (pprint/pprint value))))
 
+
 (defn valid-fabricate-hiccup?
   [v]
-  (let [valid? (fabricate-hiccup-validator v)]
-    (when-not valid?
-      (let [{:keys [errors schema value] :as explained}
-            (fabricate-hiccup-explainer v)]
-        (pprint/pprint (me/humanize explained))
-        (println (count errors) "errors detected")
-        (run! debug-entry-error errors)))
-    valid?))
+  (nil? (mp/explain fabricate-hiccup-schema v))
+  #_(let [valid? (fabricate-hiccup-validator v)]
+      (when-not valid?
+        (let [{:keys [errors schema value] :as explained}
+              (fabricate-hiccup-explainer v)]
+          (pprint/pprint (me/humanize explained))
+          (println (count errors) "errors detected")
+          (run! debug-entry-error errors)))
+      valid?))
 
 (defn valid-output-hiccup? [hiccup-data] (html/element? hiccup-data))
 
@@ -287,20 +290,37 @@
         ;; uncomment this when the schema supports lists/seqs of elements!
         #_(t/is (valid-schema? html/element data)
                 "api/produce should produce valid Hiccup elements")
-        (pprint/print-table ["type" "subType" "extract" "message"]
-                            (get validation-result "messages"))
-        (t/is (empty? (into []
-                            (filter #(and (= "error" (get % "type"))
-                                          ;; known bug: current version of
-                                          ;; validator detects CSS layer
-                                          ;; directive as invalid
-                                          (not (re-find #"CSS.*@layer"
-                                                        (get % "message")))
-                                          ;; no support for CSS subgrid in
-                                          ;; 2026?
-                                          (not (re-find #"CSS.*subgrid"
-                                                        (get % "message")))))
-                            (get validation-result "messages"))))))))
+        (binding [pprint/*print-miser-width*  60
+                  pprint/*print-right-margin* 75]
+          (pprint/pprint
+           (mapv #(select-keys % ["type" "subType" "extract" "message"])
+                 (get validation-result "messages"))))
+        (t/is
+         (empty?
+          (into
+           []
+           (remove
+            #(or
+              (#{"info" "warning"} (get % "type"))
+              (and
+               (= "error" (get % "type"))
+               (or
+                ;; <dt> within <div> elements within <dl> elements have
+                ;; been valid HTML since 2017 (HTML5.2)
+                (re-find
+                 #"Element “dt” not allowed as child of element “div” in this context."
+                 (get % "message"))
+                (re-find #"skipping \d heading levels" (get % "message"))
+                ;; known bug: current version of
+                ;; validator detects CSS layer
+                ;; directive as invalid
+                (re-find #"CSS.*layer" (get % "message"))
+                ;; no support for CSS subgrid in 2026?
+                (re-find #"CSS.*subgrid" (get % "message"))
+                (re-find #"CSS.*" (get % "message"))))))
+           (get validation-result "messages"))))))))
+
+
 
 (defn unregister-multimethods!
   "clean up + unmap test-specific multimethod impls"

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -25,7 +25,8 @@
             [babashka.fs :as fs]
             [clojure.java.io :as io]
             [clojure.walk :as walk]
-            [clojure.data.json :as json])
+            [clojure.data.json :as json]
+            [malli.util :as mu])
   (:import [nu.validator.validation SimpleDocumentValidator]
            [nu.validator.client EmbeddedValidator]
            [java.io ByteArrayInputStream]))
@@ -111,24 +112,9 @@
            results)))))
   ([] (register-collect-methods! pattern-formats)))
 
-(comment
-  (fs/parent (fs/path "../something"))
-  (fs/directory? (fs/canonicalize (fs/absolutize (fs/path "../something")))))
 
 (def entry? (m/validator api/Entry))
 
-(def fabricate-hiccup-schema
-  (m/schema [:schema
-             (assoc-in (m/properties html/element)
-              [:registry ::fabricate-hiccup]
-              [:cat :keyword [:? :map]
-               [:*
-                [:or [:schema [:ref ::html/element]]
-                 (m/schema eval/Evaluated-Form)
-                 [:schema [:ref ::fabricate-hiccup]]]]]) ::fabricate-hiccup]))
-
-(def fabricate-hiccup-validator (m/validator fabricate-hiccup-schema))
-(def fabricate-hiccup-explainer (m/explainer fabricate-hiccup-schema))
 
 (defn debug-entry-error
   [{:keys [path in value schema] :as error}]
@@ -138,18 +124,6 @@
     (binding [*print-length* 5 *print-level* 1] (pprint/pprint value))
     (binding [*print-length* 20 *print-level* 4] (pprint/pprint value))))
 
-
-(defn valid-fabricate-hiccup?
-  [v]
-  (nil? (mp/explain fabricate-hiccup-schema v))
-  #_(let [valid? (fabricate-hiccup-validator v)]
-      (when-not valid?
-        (let [{:keys [errors schema value] :as explained}
-              (fabricate-hiccup-explainer v)]
-          (pprint/pprint (me/humanize explained))
-          (println (count errors) "errors detected")
-          (run! debug-entry-error errors)))
-      valid?))
 
 (defn valid-output-hiccup? [hiccup-data] (html/element? hiccup-data))
 
@@ -196,13 +170,7 @@
     (doseq [{:keys [site.fabricate.source/location] :as e} entries]
       (when (#{::hiccup} (e :site.fabricate.document/format))
         (t/testing (str "\nentry: " location)
-          (t/is (match? {:site.fabricate.document/data
-                         (match/pred #_valid-fabricate-hiccup?
-                                     vector?
-                                     "Valid Hiccup with nested Kindly expected")
-                         :site.fabricate.document/title
-                         (match/pred string? "Document title expected")}
-                        e))))))
+          (t/is (valid-schema? props/FabricateHiccupEntry e))))))
   site)
 
 (def assemble-tasks [check-hiccup-entries])

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -28,9 +28,6 @@
            [nu.validator.client EmbeddedValidator]
            [java.io ByteArrayInputStream]))
 
-
-
-
 (t/use-fixtures :once test-utils/with-instrumentation)
 
 (def manual-site-config
@@ -55,7 +52,6 @@
    {:site.fabricate/site-name  (str (fs/parent site-dir))
     :site.fabricate.source/original-location site-dir
     :site.fabricate.source/dir site-dir}})
-
 
 (defn copy-to-test-dir!
   "Copies the site's source dir to the test location."
@@ -108,7 +104,6 @@
   ([] (register-collect-methods! pattern-formats)))
 
 (def entry? (m/validator api/Entry))
-
 
 (def fabricate-hiccup-schema
   (m/schema [:schema
@@ -179,7 +174,6 @@
           (assoc :site.fabricate.document/data data)
           (merge page-metadata)))))
 
-
 (defn check-hiccup-entries
   [{:keys [site.fabricate.api/entries] :as site}]
   (binding [*print-length* (if (test-utils/cli-test?) 5 10)
@@ -221,27 +215,37 @@
 
 (def kindly-map? (m/validator eval/Evaluated-Form))
 
-;; pre and post assertions for process-kinds
-;; 1. count the number of nil :values in the kindly forms + ensure the
-;; post-walked form has the same number of nils
-;; 2.
-
+;; TODO: reimplement the post assertions as part of a malli schema
 (defn process-kinds
   [form page-format]
-  (walk/postwalk
-   (fn [v]
-     (if (kindly-map? v)
-       (let [output (api/render-form
-                     (assoc v :site.fabricate.page/format page-format))
-             unexpected-nil-output? (and (nil? output) (some? (:value v)))]
-         (when unexpected-nil-output? (pprint/pprint v))
-         (t/is (not unexpected-nil-output?)
-               "Non-nil values should not be returned as nil after rendering")
-         (t/is (not (kindly-map? output))
-               "All kindly maps should be transformed")
-         output)
-       v))
-   form))
+  (try
+    (walk/postwalk
+     (fn [v]
+       (if (kindly-map? v)
+         (let [{:keys [kind value kindly/hide-code kindly/hide-value] :as v}
+               (assoc v :site.fabricate.page/format page-format)
+               output (api/render-form v)
+               unexpected-nil-output?
+               (and (nil? output) (some? value) (not (:kindly/hide-value v)))
+               unexpected-output (and hide-code hide-value (some? output))]
+           (t/is
+            (not unexpected-output)
+            "Values should not be returned when :kindly/hide-code and :kindly/hide-value are both true")
+           (when unexpected-nil-output? (pprint/pprint v))
+           (t/is
+            (not unexpected-nil-output?)
+            (str
+             "Non-nil values should not be returned as nil after rendering kind "
+             kind
+             " to output format " page-format))
+           (t/is (not (kindly-map? output))
+                 "All kindly maps should be transformed")
+           output)
+         v))
+     form)
+    (catch Exception e
+      (do (println "encountered an error processing form")
+          #_(pprint/pprint form)))))
 
 (def html-validator
   (doto (EmbeddedValidator.)
@@ -260,26 +264,22 @@
 
 (defn register-produce-methods!
   []
-  (defmethod api/display-form [:kind/hiccup :chassis/hiccup]
-    [form]
-    (process-hiccup-form form))
-  (defmethod api/display-form [:hiccup :hiccup/html]
-    [form]
-    (process-hiccup-form form))
-  (defmethod api/display-form [:code :hiccup/html]
-    [form]
-    (process-hiccup-form form))
+  (defmethod api/display-form [:fabricate/error :hiccup/html]
+    [{:keys [value] :as form}]
+    (site.fabricate.prototype.read/error->hiccup (assoc form :error value)))
   (defmethod api/produce! [::hiccup :chassis/hiccup]
     [{:keys [site.fabricate.document/title] :as entry} opts]
-    (t/testing (str title)
+    (t/testing (str "\n" title)
       (let [{:keys [site.fabricate.document/data] :as processed-entry}
             (update entry
                     :site.fabricate.document/data
-                    #(process-kinds % :chassis/hiccup))
+                    #(process-kinds % :hiccup/html))
             output-hiccup     [chassis/doctype-html5
                                (hiccup/entry->hiccup-head processed-entry)
                                (hiccup/entry->hiccup-body processed-entry)]
-            output-html       (chassis/html output-hiccup)
+            output-html       (try (chassis/html output-hiccup)
+                                   (catch Exception e
+                                     "<<<HTML RENDERING ERROR>>>"))
             validation-result (validate-html-string output-html)]
         #_(t/is (match? {:site.fabricate.document/title string?}
                         processed-entry)
@@ -301,7 +301,6 @@
                                           (not (re-find #"CSS.*subgrid"
                                                         (get % "message")))))
                             (get validation-result "messages"))))))))
-
 
 (defn unregister-multimethods!
   "clean up + unmap test-specific multimethod impls"
@@ -328,12 +327,7 @@
                             (#'site.fabricate.api/assemble assemble-tasks)
                             (#'site.fabricate.api/construct!
                              [unregister-multimethods!]))
-                       :done)))))
-      (t/testing "validity of generated page contents"
-                 ;; TODO: validate the Hiccup passed to Chassis during
-                 ;; `api/produce!` using the HTML namespace
-      ))))
-
+                       :done))))))))
 
 (t/deftest sites
   ;; only define the multimethods at runtime

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -1,9 +1,14 @@
 (ns site.fabricate.build-test
   (:require [clojure.test :as t]
+            [matcher-combinators.test]
+            [matcher-combinators.matchers :as match]
+            [matcher-combinators.config :as match-config]
             [clojure.string :as str]
             [site.fabricate.api :as api]
             [site.fabricate.dev.build :as build]
             [site.fabricate.prototype.html :as html]
+            [site.fabricate.prototype.document.clojure :as clj]
+            [site.fabricate.prototype.document.fabricate :as fab]
             [malli.core :as m]
             [babashka.fs :as fs]
             [clojure.java.io :as io]))
@@ -83,8 +88,8 @@
   ([] (register-collect-methods! pattern-formats)))
 
 (def entry? (m/validator api/Entry))
-
-(defn valid-fabricate-hiccup? [hiccup-data])
+(defn valid-fabricate-hiccup? [hiccup-data] vector?)
+(defn valid-output-hiccup? [hiccup-data] (html/element? hiccup-data))
 
 (defn build-fabricate
   "Build and test the entry from a Fabricate template"
@@ -92,10 +97,40 @@
   {:pre [(t/is (entry? entry))] :post [(t/is (and (entry? %)))]}
   entry)
 
-#_(defmethod api/build)
-#_(defmethod api/build)
+(defn build-clojure
+  "Build and test the entry from a Clojure source"
+  [entry]
+  {:pre [(t/is (entry? entry))] :post [(t/is (and (entry? %)))]}
+  entry)
 
-(defn valid-output-hiccup? [hiccup-data] (html/element? hiccup-data))
+(defn register-build-methods!
+  []
+  (defmethod api/build [::fabricate ::hiccup]
+    [{:keys [site.fabricate.source/location] :as entry} opts]
+    (let [hiccup-article (fab/entry->hiccup-article entry opts)]
+      (assoc entry :site.fabricate.document/data hiccup-article)))
+  (defmethod api/build [::clojure ::hiccup]
+    [{:keys [site.fabricate.source/location] :as entry} opts]
+    (let [data (-> location
+                   clj/read-forms
+                   clj/eval-forms
+                   clj/forms->hiccup)]
+      (assoc entry :site.fabricate.document/data data))))
+
+
+(defn check-hiccup-entries
+  [{:keys [site.fabricate.api/entries] :as site}]
+  (binding [*print-length* 10
+            *print-level*  5]
+    (doseq [{:keys [site.fabricate.source/location] :as e} entries]
+      (t/testing (str "\nentry: " location)
+        (t/is (match? {:site.fabricate.document/data
+                       (match/pred valid-fabricate-hiccup?
+                                   "Valid Hiccup with nested Kindly expected")}
+                      e)))))
+  site)
+
+(def assemble-tasks [check-hiccup-entries])
 
 (defn test-site
   [{:keys [site.fabricate.dev.build/setup-tasks site.fabricate.api/options]
@@ -108,7 +143,7 @@
           (t/is (= :done
                    (do (->> site-config
                             (#'site.fabricate.api/plan! setup-tasks)
-                            (#'site.fabricate.api/assemble [])
+                            (#'site.fabricate.api/assemble assemble-tasks)
                             (#'site.fabricate.api/construct! []))
                        :done)))))
       (t/testing "validity of generated page contents"
@@ -119,6 +154,9 @@
 (t/deftest sites
   ;; only define the multimethods at runtime
   (register-collect-methods!)
+  (register-build-methods!)
   (run! test-site (into [manual-site-config] additional-sites))
   ;; clean up + unmap test-specific multimethod impls
-  (run! (partial remove-method api/collect) (keys pattern-formats)))
+  (run! (partial remove-method api/collect) (keys pattern-formats))
+  (run! (partial remove-method api/build)
+        [[::fabricate ::hiccup] [::clojure ::hiccup]]))

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -1,5 +1,6 @@
 (ns site.fabricate.build-test
   (:require [clojure.test :as t]
+            [clojure.pprint :as pprint]
             [matcher-combinators.test]
             [matcher-combinators.matchers :as match]
             [matcher-combinators.config :as match-config]
@@ -7,12 +8,17 @@
             [site.fabricate.api :as api]
             [site.fabricate.dev.build :as build]
             [site.fabricate.prototype.html :as html]
+            [site.fabricate.prototype.eval :as eval]
             [site.fabricate.prototype.kindly :as kindly]
             [site.fabricate.prototype.document.clojure :as clj]
             [site.fabricate.prototype.document.fabricate :as fab]
+            [site.fabricate.prototype.test-utils :as test-utils]
             [malli.core :as m]
+            [malli.error :as me]
             [babashka.fs :as fs]
             [clojure.java.io :as io]))
+
+(t/use-fixtures :once test-utils/with-instrumentation)
 
 (def manual-site-config
   {:site.fabricate.api/options
@@ -97,10 +103,31 @@
               [:registry ::fabricate-hiccup]
               [:cat :keyword [:? :map]
                [:*
-                [:or [:schema [:ref ::html/element]] (m/schema kindly/Form)
+                [:or [:schema [:ref ::html/element]]
+                 (m/schema eval/Evaluated-Form)
                  [:schema [:ref ::fabricate-hiccup]]]]]) ::fabricate-hiccup]))
 
-(def valid-fabricate-hiccup? (m/validator fabricate-hiccup-schema))
+(def fabricate-hiccup-validator (m/validator fabricate-hiccup-schema))
+(def fabricate-hiccup-explainer (m/explainer fabricate-hiccup-schema))
+
+(defn debug-entry-error
+  [{:keys [path in value schema] :as error}]
+  (println "Did not match schema")
+  (pprint/pprint schema)
+  (if (test-utils/cli-test?)
+    (binding [*print-length* 5 *print-level* 1] (pprint/pprint value))
+    (binding [*print-length* 20 *print-level* 4] (pprint/pprint value))))
+
+(defn valid-fabricate-hiccup?
+  [v]
+  (let [valid? (fabricate-hiccup-validator v)]
+    (when-not valid?
+      (let [{:keys [errors schema value] :as explained}
+            (fabricate-hiccup-explainer v)]
+        (pprint/pprint (me/humanize explained))
+        (println (count errors) "errors detected")
+        (run! debug-entry-error errors)))
+    valid?))
 
 (defn valid-output-hiccup? [hiccup-data] (html/element? hiccup-data))
 
@@ -133,14 +160,17 @@
 
 (defn check-hiccup-entries
   [{:keys [site.fabricate.api/entries] :as site}]
-  (binding [*print-length* 10
-            *print-level*  5]
+  (binding [*print-length* (if (test-utils/cli-test?) 5 10)
+            *print-level*  (if (test-utils/cli-test?) 1 5)]
     (doseq [{:keys [site.fabricate.source/location] :as e} entries]
-      (t/testing (str "\nentry: " location)
-        (t/is (match? {:site.fabricate.document/data
-                       (match/pred valid-fabricate-hiccup?
-                                   "Valid Hiccup with nested Kindly expected")}
-                      e)))))
+      (when (#{::fabricate ::clojure} (e :site.fabrciate.document/format))
+        (t/testing (str "\nentry: " location)
+          (t/is (match? {:site.fabricate.document/data
+                         (match/pred
+                          #_valid-fabricate-hiccup?
+                          vector?
+                          "Valid Hiccup with nested Kindly expected")}
+                        e))))))
   site)
 
 (def assemble-tasks [check-hiccup-entries])
@@ -168,6 +198,7 @@
   ;; only define the multimethods at runtime
   (register-collect-methods!)
   (register-build-methods!)
+  (if (test-utils/cli-test?) (match-config/enable-abbreviation!))
   (run! test-site (into [manual-site-config] additional-sites))
   ;; clean up + unmap test-specific multimethod impls
   (run! (partial remove-method api/collect) (keys pattern-formats))

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -16,6 +16,7 @@
             [site.fabricate.prototype.page :as page]
             [site.fabricate.prototype.hiccup :as prototype.hiccup]
             [site.fabricate.prototype.document.fabricate :as fab]
+            [site.fabricate.prototype.properties :as props]
             [site.fabricate.prototype.test-utils :as test-utils]
             [dev.onionpancakes.chassis.core :as chassis]
             [malli.core :as m]
@@ -79,6 +80,8 @@
 (def pattern-formats
   {(str test-dir "/**/*.fab") ::fabricate (str test-dir "/**/*.clj") ::clojure})
 
+(defn build-test-collect [] nil)
+
 (defn register-collect-methods!
   ([pattern-formats]
    (doseq [[pattern fmt] pattern-formats]
@@ -86,23 +89,31 @@
        [pattern {:keys [site.fabricate.source/dir] :as opts}]
        (t/testing (str pattern ":")
          (let [pattern (str (fs/file "**" (fs/file-name pattern)))
-               results (mapv (fn [p]
+               results (mapv (fn collect-entry [p]
                                ;; using namespace-specific formats ensures
                                ;; that the tests never clash with other
                                ;; default multimethods
-                               {:site.fabricate.source/format fmt
+                               {:site.fabricate.source/file
+                                (fs/file (fs/canonicalize (fs/absolutize p)))
+                                :site.fabricate.source/format fmt
                                 :site.fabricate.document/format ::hiccup
                                 :site.fabricate.page/format :chassis/hiccup
                                 ::api/source pattern
                                 :site.fabricate.source/original-location
                                 (:site.fabricate.source/original-location opts)
-                                :site.fabricate.source/location (fs/file p)})
+                                :site.fabricate.source/directory
+                                (fs/parent (fs/canonicalize (fs/absolutize p)))
+                                :site.fabricate.source/location
+                                (fs/file (fs/canonicalize (fs/absolutize p)))})
                              (fs/glob dir pattern))]
-           (t/is (every? fs/exists?
-                         (map :site.fabricate.source/location results))
-                 (str "every collected entry should exist"))
+           (t/is (valid-schema? (m/schema [:* props/CollectedEntry]) results)
+                 (str "every collected entry should match expected schema"))
            results)))))
   ([] (register-collect-methods! pattern-formats)))
+
+(comment
+  (fs/parent (fs/path "../something"))
+  (fs/directory? (fs/canonicalize (fs/absolutize (fs/path "../something")))))
 
 (def entry? (m/validator api/Entry))
 
@@ -157,7 +168,8 @@
 (defn register-build-methods!
   []
   (defmethod api/build [::fabricate ::hiccup]
-    [{:keys [site.fabricate.source/location] :as entry} opts]
+    [{:keys [site.fabricate.source/location site.fabricate.source/file]
+      :as   entry} opts]
     (let [hiccup-article (fab/entry->hiccup-article entry opts)
           page-metadata  (meta hiccup-article)]
       (assoc entry

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -5,6 +5,7 @@
             [matcher-combinators.matchers :as match]
             [matcher-combinators.config :as match-config]
             [clojure.string :as str]
+            [clojure.set :as set]
             [site.fabricate.api :as api]
             [site.fabricate.dev.build :as build]
             [site.fabricate.prototype.html :as html]
@@ -13,10 +14,19 @@
             [site.fabricate.prototype.document.clojure :as clj]
             [site.fabricate.prototype.document.fabricate :as fab]
             [site.fabricate.prototype.test-utils :as test-utils]
+            [dev.onionpancakes.chassis.core :as chassis]
             [malli.core :as m]
             [malli.error :as me]
             [babashka.fs :as fs]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [clojure.walk :as walk]
+            [clojure.data.json :as json])
+  (:import [nu.validator.validation SimpleDocumentValidator]
+           [nu.validator.client EmbeddedValidator]
+           [java.io ByteArrayInputStream]))
+
+
+
 
 (t/use-fixtures :once test-utils/with-instrumentation)
 
@@ -82,7 +92,7 @@
                                ;; default multimethods
                                {:site.fabricate.source/format fmt
                                 :site.fabricate.document/format ::hiccup
-                                :site.fabricate.page/format ::hiccup-html
+                                :site.fabricate.page/format :chassis/hiccup
                                 ::api/source pattern
                                 :site.fabricate.source/original-location
                                 (:site.fabricate.source/original-location opts)
@@ -175,6 +185,65 @@
 
 (def assemble-tasks [check-hiccup-entries])
 
+(def key-lookup
+  {:kind        :data-kind
+   :kindly/kind :data-kind
+   :kindly/hide-code :data-kindly-hide-code})
+(defn with-keys
+  [map kmap]
+  (-> map
+      (select-keys (keys kmap))
+      (set/rename-keys kmap)))
+
+(defn process-hiccup-form
+  [{:keys [kind value] :as form}]
+  (let [data-attrs (with-keys form key-lookup)]
+    (chassis/apply-normalized (fn add-data-attrs [tag attrs contents]
+                                (into [tag (merge attrs data-attrs)] contents))
+                              value)))
+
+(def kindly-map? (m/validator eval/Evaluated-Form))
+
+(defn process-kinds
+  [form page-format]
+  (walk/postwalk (fn [v] (if (kindly-map? v) (api/display-form v page-format)))
+                 form))
+
+(def html-validator
+  (doto (EmbeddedValidator.)
+    (.setOutputFormat nu.validator.client.EmbeddedValidator$OutputFormat/JSON)))
+
+(defn validate-html-string
+  [html-string]
+  (let [html-input-stream (ByteArrayInputStream. (.getBytes html-string))]
+    (try (let [validator-output (.validate html-validator html-input-stream)]
+           (if (empty? validator-output) {} (json/read-str validator-output)))
+         (catch Exception e (Throwable->map e)))))
+
+(comment
+  (validate-html-string (chassis/html [chassis/doctype-html5
+                                       [:head [:title "test"]] [:body]])))
+
+(defn register-produce-methods!
+  []
+  (defmethod api/display-form [:kind/hiccup :chassis/hiccup]
+    [form]
+    (process-hiccup-form form))
+  (defmethod api/produce! [::hiccup :chassis/hiccup]
+    [{:keys [site.fabricate.document/data] :as entry} opts]
+    (let [processed-hiccup  (process-kinds data :chassis/hiccup)
+          output-hiccup     [chassis/doctype-html5 [:head]
+                             [:body processed-hiccup]]
+          output-html       (chassis/html output-hiccup)
+          validation-result (validate-html-string output-html)]
+      (t/is (valid-schema? html/element processed-hiccup)
+            "api/produce should produce valid Hiccup elements")
+      (pprint/print-table ["type" "subType" "extract" "message"]
+                          (get validation-result "messages"))
+      (t/is (empty? (into []
+                          (filter #(= "error" (get % "type")))
+                          (get validation-result "messages")))))))
+
 (defn test-site
   [{:keys [site.fabricate.dev.build/setup-tasks site.fabricate.api/options]
     :or   {setup-tasks []}
@@ -198,9 +267,13 @@
   ;; only define the multimethods at runtime
   (register-collect-methods!)
   (register-build-methods!)
+  (register-produce-methods!)
   (if (test-utils/cli-test?) (match-config/enable-abbreviation!))
   (run! test-site (into [manual-site-config] additional-sites))
   ;; clean up + unmap test-specific multimethod impls
   (run! (partial remove-method api/collect) (keys pattern-formats))
   (run! (partial remove-method api/build)
-        [[::fabricate ::hiccup] [::clojure ::hiccup]]))
+        [[::fabricate ::hiccup] [::clojure ::hiccup]])
+  (run! (partial remove-method api/produce!) [[::hiccup :chassis/hiccup]])
+  (run! (partial remove-method api/display-form)
+        [[:kind/hiccup] :chassis/hiccup]))

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -8,6 +8,7 @@
             [clojure.set :as set]
             [site.fabricate.api :as api]
             [site.fabricate.dev.build :as build]
+            [site.fabricate.dev.html :as html-check]
             [site.fabricate.prototype.html :as html]
             [site.fabricate.prototype.eval :as eval]
             [site.fabricate.prototype.kindly :as kindly]
@@ -25,11 +26,7 @@
             [babashka.fs :as fs]
             [clojure.java.io :as io]
             [clojure.walk :as walk]
-            [clojure.data.json :as json]
-            [malli.util :as mu])
-  (:import [nu.validator.validation SimpleDocumentValidator]
-           [nu.validator.client EmbeddedValidator]
-           [java.io ByteArrayInputStream]))
+            [malli.util :as mu]))
 
 (t/use-fixtures :once test-utils/with-instrumentation)
 
@@ -230,20 +227,8 @@
       (do (println "encountered an error processing form")
           #_(pprint/pprint form)))))
 
-(def html-validator
-  (doto (EmbeddedValidator.)
-    (.setOutputFormat nu.validator.client.EmbeddedValidator$OutputFormat/JSON)))
 
-(defn validate-html-string
-  [html-string]
-  (let [html-input-stream (ByteArrayInputStream. (.getBytes html-string))]
-    (try (let [validator-output (.validate html-validator html-input-stream)]
-           (if (empty? validator-output) {} (json/read-str validator-output)))
-         (catch Exception e (Throwable->map e)))))
 
-(comment
-  (validate-html-string (chassis/html [chassis/doctype-html5
-                                       [:head [:title "test"]] [:body]])))
 
 (defn register-produce-methods!
   []
@@ -263,7 +248,7 @@
             output-html       (try (chassis/html output-hiccup)
                                    (catch Exception e
                                      "<<<HTML RENDERING ERROR>>>"))
-            validation-result (validate-html-string output-html)]
+            validation-result (html-check/validate-html-string output-html)]
         #_(t/is (match? {:site.fabricate.document/title string?}
                         processed-entry)
                 "Each entry should have a title")

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -12,6 +12,8 @@
             [site.fabricate.prototype.eval :as eval]
             [site.fabricate.prototype.kindly :as kindly]
             [site.fabricate.prototype.document.clojure :as clj]
+            [site.fabricate.prototype.page.hiccup :as hiccup]
+            [site.fabricate.prototype.hiccup :as prototype.hiccup]
             [site.fabricate.prototype.document.fabricate :as fab]
             [site.fabricate.prototype.test-utils :as test-utils]
             [dev.onionpancakes.chassis.core :as chassis]
@@ -157,15 +159,24 @@
   []
   (defmethod api/build [::fabricate ::hiccup]
     [{:keys [site.fabricate.source/location] :as entry} opts]
-    (let [hiccup-article (fab/entry->hiccup-article entry opts)]
-      (assoc entry :site.fabricate.document/data hiccup-article)))
+    (let [hiccup-article (fab/entry->hiccup-article entry opts)
+          page-metadata  (meta hiccup-article)]
+      (assoc entry
+             :site.fabricate.document/data  hiccup-article
+             :site.fabricate.document/title (:title page-metadata))))
   (defmethod api/build [::clojure ::hiccup]
     [{:keys [site.fabricate.source/location] :as entry} opts]
     (let [data (-> location
                    clj/read-forms
                    clj/eval-forms
-                   clj/forms->hiccup)]
-      (assoc entry :site.fabricate.document/data data))))
+                   clj/forms->hiccup)
+          page-metadata (-> data
+                            (get-in [1 :data-clojure-namespace])
+                            (find-ns)
+                            meta)]
+      (-> entry
+          (assoc :site.fabricate.document/data data)
+          (merge page-metadata)))))
 
 
 (defn check-hiccup-entries
@@ -173,13 +184,14 @@
   (binding [*print-length* (if (test-utils/cli-test?) 5 10)
             *print-level*  (if (test-utils/cli-test?) 1 5)]
     (doseq [{:keys [site.fabricate.source/location] :as e} entries]
-      (when (#{::fabricate ::clojure} (e :site.fabrciate.document/format))
+      (when (#{::hiccup} (e :site.fabricate.document/format))
         (t/testing (str "\nentry: " location)
           (t/is (match? {:site.fabricate.document/data
-                         (match/pred
-                          #_valid-fabricate-hiccup?
-                          vector?
-                          "Valid Hiccup with nested Kindly expected")}
+                         (match/pred #_valid-fabricate-hiccup?
+                                     vector?
+                                     "Valid Hiccup with nested Kindly expected")
+                         :site.fabricate.document/title
+                         (match/pred string? "Document title expected")}
                         e))))))
   site)
 
@@ -206,7 +218,12 @@
 
 (defn process-kinds
   [form page-format]
-  (walk/postwalk (fn [v] (if (kindly-map? v) (api/display-form v page-format)))
+  (walk/postwalk (fn [v]
+                   (if (kindly-map? v)
+                     (let [output (api/display-form v page-format)]
+                       #_(t/is (not (kindly-map? output))
+                               "All kindly maps should be transformed")
+                       output)))
                  form))
 
 (def html-validator
@@ -230,18 +247,29 @@
     [form]
     (process-hiccup-form form))
   (defmethod api/produce! [::hiccup :chassis/hiccup]
-    [{:keys [site.fabricate.document/data] :as entry} opts]
-    (let [processed-hiccup  (process-kinds data :chassis/hiccup)
-          output-hiccup     [chassis/doctype-html5 [:head]
-                             [:body processed-hiccup]]
+    [entry opts]
+    (let [{:keys [site.fabricate.document/data] :as processed-entry}
+          (update entry
+                  :site.fabricate.document/data
+                  #(process-kinds % :chassis/hiccup))
+          output-hiccup     [chassis/doctype-html5
+                             (hiccup/entry->hiccup-head processed-entry)
+                             (hiccup/entry->hiccup-body processed-entry)]
           output-html       (chassis/html output-hiccup)
           validation-result (validate-html-string output-html)]
-      (t/is (valid-schema? html/element processed-hiccup)
+      #_(t/is (match? {:site.fabricate.document/title string?} processed-entry)
+              "Each entry should have a title")
+      (t/is (valid-schema? html/element data)
             "api/produce should produce valid Hiccup elements")
       (pprint/print-table ["type" "subType" "extract" "message"]
                           (get validation-result "messages"))
       (t/is (empty? (into []
-                          (filter #(= "error" (get % "type")))
+                          (filter #(and (= "error" (get % "type"))
+                                        ;; known bug: current version of
+                                        ;; validator detects CSS layer
+                                        ;; directive as invalid
+                                        (not (re-find #"CSS.*@layer"
+                                                      (get % "message")))))
                           (get validation-result "messages")))))))
 
 (defn test-site

--- a/test/site/fabricate/build_test.clj
+++ b/test/site/fabricate/build_test.clj
@@ -1,0 +1,49 @@
+(ns site.fabricate.build-test
+  (:require [clojure.test :as t]
+            [clojure.string :as str]
+            [site.fabricate.api :as api]
+            [site.fabricate.dev.build :as build]
+            [babashka.fs :as fs]
+            [clojure.java.io :as io]))
+
+(def manual-site-config
+  {:site.fabricate.page/publish-dir       (fs/create-temp-dir)
+   :site.fabricate.build-test/setup-tasks (drop-last
+                                           3
+                                           site.fabricate.dev.build/setup-tasks)
+   :site.fabricate.source/source-dir
+   ;; eventually the manual should provide pages to the library
+   ;; using resources on the classpath so it can be: (io/resource ...)
+   ;; so these tests run in CI
+   "../fabricate-manual/docs"})
+
+(defn path->site-config
+  [site-dir]
+  {:site.fabricate/site-name         (str (fs/parent site-dir))
+   :site.fabricate.source/source-dir site-dir})
+
+(def additional-sites
+  (if-let [test-sites (System/getProperty "site.fabricate.build-test.dirs")]
+    (mapv path->site-config (str/split test-sites #","))
+    []))
+
+(defn test-site
+  [{:keys [site.fabricate.source/source-dir
+           site.fabricate.dev.build/setup-tasks]
+    :or   {setup-tasks []}
+    :as   site-config}]
+  (when (fs/exists? source-dir)
+    (t/testing (str source-dir ":")
+      (t/testing (str "ability to build without errors")
+        (t/is (= :done
+                 (do (->> {:site.fabricate.api/options site-config}
+                          (#'site.fabricate.api/plan! setup-tasks)
+                          (#'site.fabricate.api/assemble [])
+                          (#'site.fabricate.api/construct! []))
+                     :done)))))
+    (t/testing "validity of generated page contents"
+               ;; TODO: validate the Hiccup passed to Chassis during
+               ;; `api/produce!` using the HTML namespace
+    )))
+
+(t/deftest sites (run! test-site (into [manual-site-config] additional-sites)))

--- a/test/site/fabricate/prototype/eval_test.clj
+++ b/test/site/fabricate/prototype/eval_test.clj
@@ -1,9 +1,14 @@
 (ns site.fabricate.prototype.eval-test
   (:require [site.fabricate.prototype.eval :as prototype.eval]
+            [site.fabricate.prototype.kindly :as kindly]
             [site.fabricate.adorn :as adorn]
             [matcher-combinators.test]
             [matcher-combinators.matchers :as matchers]
-            [clojure.test :as t]))
+            [site.fabricate.prototype.test-utils :as test-utils]
+            [clojure.test :as t]
+            [malli.core :as m]))
+
+(t/use-fixtures :once test-utils/with-instrumentation)
 
 (t/deftest evaluation
   (t/testing ": single exprs"
@@ -48,5 +53,9 @@
                              :code "[^{:key :value} [1]]"
                              :ns   test-ns})]
         (println (meta (:value evaluated-form)))
+        (t/is (m/validate prototype.eval/Evaluated-Form evaluated-form)
+              "Form should have all required keys populated")
+        (t/is (m/validate kindly/Form evaluated-form)
+              "Form should conform to kindly map specification")
         (t/is (match? (:ns var-form) (:ns (meta (:value evaluated-form)))))
         (t/is (match? {:key :value} (meta (first (:value metadata-form)))))))))

--- a/test/site/fabricate/prototype/page_test.clj
+++ b/test/site/fabricate/prototype/page_test.clj
@@ -13,12 +13,14 @@
   (doseq [value [:a '(+ 1 2 3) 45 {:b 3}]]
     (t/testing (str "value: " value)
       (t/testing "code"
-        (t/is (valid-block? (api/display-form {:kind :code :value value}
-                                              {:site.fabricate.page/format
+        (t/is (valid-block? (api/display-form {:kind  :code
+                                               :value value
+                                               :site.fabricate.page/format
                                                :hiccup/html}))))
       (t/testing "edn"
-        (t/is (valid-block? (api/display-form {:kind :edn :value value}
-                                              {:site.fabricate.page/format
+        (t/is (valid-block? (api/display-form {:kind  :edn
+                                               :value value
+                                               :site.fabricate.page/format
                                                :hiccup/html}))))))
   (t/testing "hiccup"
     (doseq [hiccup [[:span "text"] [:code "(map dec (range 29 58 2))"]]]

--- a/test/site/fabricate/prototype/read_test.clj
+++ b/test/site/fabricate/prototype/read_test.clj
@@ -66,7 +66,7 @@
        :message  ~msg
        :expected (str (with-out-str (pprint/pprint data#))
                       " conforms to schema for "
-                      schema-name#)
+                      schema#)
        :actual   (if (not result#) (m/explain schema# data#) result#)})
      result#))
 
@@ -331,6 +331,12 @@
                                 'var-test-ns)
             form-meta (meta evaluated)]
         (tap> form-meta)
+        (t/is (valid-schema? prototype.eval/Evaluated-Form (evaluated 0))
+              "Evaluation should produce valid Kindly forms")
+        (t/is (string? (evaluated 1)))
+        (t/is (valid-schema? prototype.eval/Evaluated-Form
+                             (evaluated 2)
+                             "Evaluation should produce valid Kindly forms"))
         (t/is (some? (:namespace form-meta))
               "Namespace information should be attached to evaluated form")
         (t/is (match? {:a 3} (:metadata form-meta))

--- a/test/site/fabricate/prototype/test_utils.clj
+++ b/test/site/fabricate/prototype/test_utils.clj
@@ -3,14 +3,10 @@
             [malli.error :as me]
             [malli.instrument :as mi]
             [clojure.test :as t]
-            [clojure.pprint :as pprint]))
+            [clojure.pprint :as pprint]
+            [clojure.string :as str]))
 
-(defn with-instrumentation
-  [f]
-  (mi/collect!)
-  (mi/instrument!)
-  (f)
-  (mi/unstrument!))
+(defn cli-test? [] (= "cli.test" (System/getProperty "clojure.context")))
 
 (defmethod t/assert-expr 'valid-schema?
   [msg form]
@@ -18,16 +14,31 @@
          form#        (m/form schema#)
          data#        ~(nth form 2)
          result#      (m/validate schema# data#)
-         schema-name# (last form#)]
-     (t/do-report {:type     (if result# :pass :fail)
-                   :message  ~msg
-                   :expected (str (with-out-str (pprint/pprint data#))
-                                  " conforms to schema for "
-                                  schema-name#)
-                   :actual   (if (not result#)
-                               (me/humanize (m/explain schema# data#))
-                               result#)})
+         schema-name# (last form#)
+         desc#        (get (m/properties schema#) :description)]
+     (t/do-report {:type (if result# :pass :fail)
+                   :message ~msg
+                   :expected
+                   #_(str (with-out-str (pprint/pprint data#))
+                          " conforms to schema"
+                          (when desc# (str ": " desc#)))
+                   `(m/validate ~schema# ~data#)
+                   :actual (if (not result#)
+                             (me/humanize (m/explain schema# data#))
+                             result#)})
      result#))
+
+(defn with-instrumentation
+  "Test fixture enabling malli instrumentation to check function conformance to malli schemas"
+  [f]
+  (mi/collect!)
+  (mi/instrument!
+   {:report (fn report [key {:keys [output value] :as error-data}]
+              (when output
+                (t/is (valid-schema? output value)
+                      "Instrumented function didn't conform to schema")))})
+  (f)
+  (mi/unstrument!))
 
 (defn gather-test-meta
   "Obtain information about the current test as a map"


### PR DESCRIPTION
This PR adds a `site.fabricate.build-test` namespace which uses Fabricate's configuration-as-code logic to allow testing an arbitrary number of sites against the original codebase with precise feedback controlled by Malli schemas with custom error reporting defined in `site.fabricate.prototype.properties`. The properties include:

- Canonicalization of source paths
- Correct handling of all embedded Kindly form maps in nested Hiccup structures
- Validity of output HTML after serialization from Hiccup

